### PR TITLE
Add north DB targeting for fit updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ mkts-backend.log
 archive/
 dev.py
 src/mkts_backend/utils/local_dev/
+fit_schemas.md
+new_zealot993.txt

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ dev.py
 src/mkts_backend/utils/local_dev/
 fit_schemas.md
 new_zealot993.txt
+*.txt

--- a/doctrine_update_feature.md
+++ b/doctrine_update_feature.md
@@ -33,3 +33,9 @@ There is a great deal of existing code from my past incomplete attempts to imple
 - Determine which tables will need to be updated for existing fits and new fits. 
 - Plan the code that will be required. 
 - Plan a refactor of existing code to centralize and streamline the implementation of this functionality.
+
+## Usage (implemented)
+- Run the CLI to update a fit from EFT text + metadata:  
+  `mkts-backend update-fit --fit-file=new_zealot993.txt --meta-file=new_zealot_metadata.json`
+- Defaults to local databases; add `--remote` to target production.  
+- Use `--no-clear` to keep existing `fittings_fittingitem` rows; `--dry-run` to preview parsed items without writing.

--- a/doctrine_update_feature.md
+++ b/doctrine_update_feature.md
@@ -1,7 +1,7 @@
 # Doctine Update Feature
 
 ## Goal
-Create simple functionality to parse an Eve Online doctrine fit from a text file in Eve Fitting Tool (EFT) format and update it in the appropriate database tables. It should be extendable to add new fits and new doctrines (which may include existing fits or new fits).
+Create simple functionality to parse an Eve Online doctrine fit from a text file in Eve Fitting Tool (EFT) format and update it in the appropriate database tables. It should be extendable to add new fits and new doctrines (which may include existing fits or new fits). These databases are the backend for two streamlit apps. 
 
 ## Desired functionality
 - User points the function to a text file containing the EFT formatted fit file and a fit Metadata file providing things like fit name and description. 
@@ -15,7 +15,7 @@ Create simple functionality to parse an Eve Online doctrine fit from a text file
 
 ## Databases
 - wcfitting.db is the master database containing fittings and doctrines. 
-- wcmktprod.db contains tables with the market information for doctrines and fits. 
+- wcmktprod.db contains tables with the market information for doctrines and fits that is used in our production streamlit app. 
 - schemas for key tables are outlined in fit_schemas.md
 
 ## Existing Code

--- a/doctrine_update_feature.md
+++ b/doctrine_update_feature.md
@@ -39,3 +39,4 @@ There is a great deal of existing code from my past incomplete attempts to imple
   `mkts-backend update-fit --fit-file=new_zealot993.txt --meta-file=new_zealot_metadata.json`
 - Defaults to local databases; add `--remote` to target production.  
 - Use `--no-clear` to keep existing `fittings_fittingitem` rows; `--dry-run` to preview parsed items without writing.
+- To target the north market DB (`wcmktnorth2.db`), add `--target=wcmktnorth` (or `--north`) to the update-fit command; other flags behave the same.

--- a/doctrine_update_feature.md
+++ b/doctrine_update_feature.md
@@ -1,0 +1,35 @@
+# Doctine Update Feature
+
+## Goal
+Create simple functionality to parse an Eve Online doctrine fit from a text file in Eve Fitting Tool (EFT) format and update it in the appropriate database tables. It should be extendable to add new fits and new doctrines (which may include existing fits or new fits).
+
+## Desired functionality
+- User points the function to a text file containing the EFT formatted fit file and a fit Metadata file providing things like fit name and description. 
+- The program should read the fitting information and update all appropriate tables automatically. 
+- The program should detect if a fitting exists and update the existing fitting, or create an entirely new one if it doesn't. 
+- The program should allow the user to select whether the updates will be applied to the local or remote (production database). 
+
+## Notes
+- Fits are a group of modules intended for a particular ship and are identified by a unique fit_id. 
+- Doctrines are groups of fits intended to be used together and are identified by a unique doctrine_id. A fit may be used in more than one doctrine. 
+
+## Databases
+- wcfitting.db is the master database containing fittings and doctrines. 
+- wcmktprod.db contains tables with the market information for doctrines and fits. 
+- schemas for key tables are outlined in fit_schemas.md
+
+## Existing Code
+There is a great deal of existing code from my past incomplete attempts to implement this feature -- some may not work. This code is contained in:
+- "src/mkts_backend/utils/parse_fits.py" (most recent attempt is the update_fits() function, which includes to dos)
+- "src/mkts_backend/utils/doctrine_update.py"
+- "src/mkts_backend/utils/add2doctrines_table.py"
+
+## Sample Files
+- "new_zealot993.txt" - EFT fit file
+- "new_zealot_metadata.json" - Fit metadata file
+
+## Assignment
+- Review the existing code and design a plan for implementing this feature. 
+- Determine which tables will need to be updated for existing fits and new fits. 
+- Plan the code that will be required. 
+- Plan a refactor of existing code to centralize and streamline the implementation of this functionality.

--- a/src/mkts_backend/config/config.py
+++ b/src/mkts_backend/config/config.py
@@ -31,6 +31,8 @@ class DatabaseConfig:
     _production_db_file = settings["db"]["production_database_file"]
     _testing_db_alias = settings["db"]["testing_database_alias"]
     _testing_db_file = settings["db"]["testing_database_file"]
+    _north_db_alias = settings["db"].get("north_database_alias", "wcmktnorth")
+    _north_db_file = settings["db"].get("north_database_file", "wcmktnorth2.db")
 
 
     _db_paths = {
@@ -38,6 +40,7 @@ class DatabaseConfig:
         "sde": "sde.db",
         "fittings": "wcfitting.db",
         _production_db_alias: _production_db_file,
+        _north_db_alias: _north_db_file,
     }
 
     _db_turso_urls = {
@@ -45,6 +48,7 @@ class DatabaseConfig:
         _testing_db_alias + "_turso": os.getenv("TURSO_WCMKTTEST_URL"),
         "sde_turso": os.getenv("TURSO_SDE_URL"),
         "fittings_turso": os.getenv("TURSO_FITTING_URL"),
+        _north_db_alias + "_turso": os.getenv("TURSO_WCMKTNORTH_URL"),
     }
 
     _db_turso_auth_tokens = {
@@ -52,6 +56,7 @@ class DatabaseConfig:
         _testing_db_alias + "_turso": os.getenv("TURSO_WCMKTTEST_TOKEN"),
         "sde_turso": os.getenv("TURSO_SDE_TOKEN"),
         "fittings_turso": os.getenv("TURSO_FITTING_TOKEN"),
+        _north_db_alias + "_turso": os.getenv("TURSO_WCMKTNORTH_TOKEN"),
     }
 
     def __init__(self, alias: str, dialect: str = "sqlite+libsql"):

--- a/src/mkts_backend/config/settings.toml
+++ b/src/mkts_backend/config/settings.toml
@@ -21,6 +21,10 @@ production_database_file = "wcmktprod.db"
 testing_database_alias = "wcmkttest"
 testing_database_file = "wcmkttest.db"
 
+# North market (secondary production) database
+north_database_alias = "wcmktnorth"
+north_database_file = "wcmktnorth2.db"
+
 [market_data]
 primary_market_region_id = 10000003
 secondary_market_region_id = 'None'

--- a/src/mkts_backend/db/models.py
+++ b/src/mkts_backend/db/models.py
@@ -171,7 +171,7 @@ class DoctrineInfo(Base):
     doctrine_id: Mapped[int] = mapped_column(Integer)
     doctrine_name: Mapped[str] = mapped_column(String)
 
-class DoctrineFit(Base):
+class DoctrineFitItems(Base):
     __tablename__ = "doctrine_fits"
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     doctrine_name: Mapped[str] = mapped_column(String)

--- a/src/mkts_backend/utils/add2doctrines_table.py
+++ b/src/mkts_backend/utils/add2doctrines_table.py
@@ -1,0 +1,161 @@
+from mkts_backend.config.config import DatabaseConfig
+from sqlalchemy import text, select, delete, func
+from sqlalchemy.orm import Session
+from mkts_backend.db.models import Doctrines
+from mkts_backend.config.logging_config import configure_logging
+import pandas as pd
+logger = configure_logging(__name__)
+
+mkt_db = DatabaseConfig("wcmkt")
+fits_db = DatabaseConfig("fittings")
+sde_db = DatabaseConfig("sde")
+
+
+def get_fit_items(fit_id: int, ship_id: int, ship_name: str)->list[Doctrines]:
+    # Aggregate by type_id and sum quantities
+    stmt = text("""
+        SELECT type_id, SUM(quantity) as total_quantity
+        FROM fittings_fittingitem
+        WHERE fit_id = :fit_id
+        GROUP BY type_id
+    """)
+    items = []
+    engine = fits_db.engine
+    with engine.connect() as conn:
+        result = conn.execute(stmt, {"fit_id": fit_id})
+        rows = result.fetchall()
+        for row in rows:
+            item = Doctrines(
+                fit_id=fit_id,
+                ship_id=ship_id,
+                type_id=row.type_id,
+                ship_name=ship_name,
+                fit_qty=row.total_quantity,  # This is now the aggregated sum
+            )
+            items.append(item)
+        items.append(Doctrines(
+            fit_id=fit_id,
+            ship_id=ship_id,
+            type_id=ship_id,
+            ship_name=ship_name,
+            fit_qty=1,
+        ))
+    return items
+
+def update_items(items: list[Doctrines]):
+    updated_items = []
+    engine = sde_db.engine
+    with engine.connect() as conn:
+        for item in items:
+            result = conn.execute(text("SELECT * FROM inv_info WHERE typeID = :type_id"), {"type_id": item.type_id})
+            new_item = result.fetchone()
+            item.type_name = new_item.typeName
+            item.group_name = new_item.groupName
+            item.category_name = new_item.categoryName
+            item.category_id = new_item.categoryID
+            item.group_id = new_item.groupID
+            updated_items.append(item)
+    return updated_items
+
+def add_items_to_doctrines_table(items: list[Doctrines], remote: bool = False):
+    engine = mkt_db.remote_engine if remote else mkt_db.engine
+    session = Session(engine)
+    with session.begin():
+        try:
+            added_count = 0
+            skipped_count = 0
+
+            for item in items:
+                # Check if this fit_id + type_id combination already exists
+                existing = session.scalar(
+                    select(Doctrines).where(
+                        Doctrines.fit_id == item.fit_id,
+                        Doctrines.type_id == item.type_id
+                    )
+                )
+
+                if existing:
+                    logger.info(f"Skipping duplicate: {item.type_name} (type_id: {item.type_id}) already exists for fit_id {item.fit_id}")
+                    skipped_count += 1
+                else:
+                    session.add(item)
+                    logger.info(f"Added {item.type_name} to doctrines {item.fit_id}")
+                    added_count += 1
+
+            session.commit()
+            logger.info(f"Completed: {added_count} items added, {skipped_count} duplicates skipped")
+
+        except Exception as e:
+            session.rollback()
+            logger.error(f"Error adding items to doctrines table: {e}")
+            raise
+        finally:
+            session.close()
+            engine.dispose()
+
+def add_fit_to_doctrines_table(fit_id: int, ship_id: int, ship_name: str, remote: bool = False, dry_run: bool = False)->list[Doctrines] | None:
+    """
+    Add a fit to the doctrines table
+    Args:
+        fit_id: int
+        ship_id: int
+        ship_name: str
+        remote: bool
+        dry_run: bool
+
+    Returns:
+        list[Doctrines] | None
+    Example:
+        add_fit_to_doctrines_table(494, 33157, "Hurricane Fleet Issue", remote=True, dry_run=False)
+
+    """
+    items = get_fit_items(fit_id, ship_id, ship_name)
+    updated_items = update_items(items)
+    if dry_run:
+        return updated_items
+    else:
+      add_items_to_doctrines_table(updated_items, remote)
+
+def select_doctrines_table(fit_id: int, remote: bool = False)->list[dict]:
+    engine = mkt_db.remote_engine if remote else mkt_db.engine
+    session = Session(engine)
+    items = []
+
+    with session.begin():
+        result = select(Doctrines).where(Doctrines.fit_id == fit_id)
+        for item in session.scalars(result):
+
+            item = item.__dict__
+            item.pop('_sa_instance_state')
+
+            items.append(item)
+    session.close()
+    engine.dispose()
+    print(f"Found {len(items)} items in doctrines table")
+    return pd.DataFrame(items)
+
+def delete_doctrines_table(fit_id: int, remote: bool = False):
+    engine = mkt_db.remote_engine if remote else mkt_db.engine
+    session = Session(engine)
+    with session.begin():
+        count = session.execute(select(func.count(Doctrines.fit_id)).where(Doctrines.fit_id == fit_id))
+        print(f"Count of {fit_id} in doctrines table: {count.scalar()}")
+        session.execute(delete(Doctrines).where(Doctrines.fit_id == fit_id))
+        session.commit()
+    session.close()
+    engine.dispose()
+    print(f"Deleted {fit_id} from doctrines table")
+
+def count_doctrines_table(fit_id: int, remote: bool = False):
+    engine = mkt_db.remote_engine if remote else mkt_db.engine
+    session = Session(engine)
+    with session.begin():
+        result = session.execute(select(func.count(Doctrines.fit_id)).where(Doctrines.fit_id == fit_id))
+        count = result.scalar()
+
+    session.close()
+    engine.dispose()
+    print(f"Item from doctrines table: {count}")
+    return count
+if __name__ == "__main__":
+    pass

--- a/src/mkts_backend/utils/add2doctrines_table.py
+++ b/src/mkts_backend/utils/add2doctrines_table.py
@@ -49,6 +49,10 @@ def update_items(items: list[Doctrines]):
         for item in items:
             result = conn.execute(text("SELECT * FROM inv_info WHERE typeID = :type_id"), {"type_id": item.type_id})
             new_item = result.fetchone()
+            if new_item is None:
+                logger.warning(f"TypeID {item.type_id} not found in inv_info; skipping")
+                continue
+
             item.type_name = new_item.typeName
             item.group_name = new_item.groupName
             item.category_name = new_item.categoryName

--- a/src/mkts_backend/utils/db_utils.py
+++ b/src/mkts_backend/utils/db_utils.py
@@ -13,7 +13,7 @@ logger = configure_logging(__name__)
 sde_db = DatabaseConfig("sde")
 wcmkt_db = DatabaseConfig("wcmkt")
 
-def add_missing_items_to_watchlist(missing_items: list[int], remote: bool = False):
+def add_missing_items_to_watchlist(missing_items: list[int], remote: bool = False, db_alias: str = "wcmkt"):
     """
     Add missing items to the watchlist by fetching type information from SDE database.
 
@@ -38,7 +38,7 @@ def add_missing_items_to_watchlist(missing_items: list[int], remote: bool = Fals
         return "No type information found for provided type IDs"
 
     # Get current watchlist to check for duplicates
-    db = DatabaseConfig("wcmkt")
+    db = DatabaseConfig(db_alias)
     logger.info(f"Database config: {db.alias}")
     logger.info(f"Remote engine: {remote}")
 
@@ -68,7 +68,7 @@ def add_missing_items_to_watchlist(missing_items: list[int], remote: bool = Fals
 
     # Insert new items into local database (not remote - we don't want to affect production watchlist)
     try:
-        db = DatabaseConfig("wcmkt")
+        db = DatabaseConfig(db_alias)
         engine = db.remote_engine if remote else db.engine
 
         with engine.connect() as conn:

--- a/src/mkts_backend/utils/db_utils.py
+++ b/src/mkts_backend/utils/db_utils.py
@@ -136,7 +136,6 @@ def update_watchlist_tables(missing_items: list[int]):
             except Exception as e:
                 logger.warning(f"Item {row['type_id']} may already exist in watchlist: {e}")
 
-
 def export_doctrines_to_csv(db_alias: str = "wcmkt", output_file: str = "doctrines_backup.csv"):
     """
     Export doctrines table to CSV for backup purposes.
@@ -291,5 +290,6 @@ def restore_watchlist_from_csv(csv_file: str = "data/watchlist_updated.csv", rem
     conn.close()
     engine.dispose()
     logger.info(f"Restored watchlist from {csv_file} to {db.alias}")
+
 if __name__ == "__main__":
     pass

--- a/src/mkts_backend/utils/doctrine_update.py
+++ b/src/mkts_backend/utils/doctrine_update.py
@@ -124,11 +124,11 @@ class DoctrineFit:
                 conn.commit()
 
 
-def upsert_doctrine_fits(doctrine_fit: DoctrineFit, remote: bool = False) -> None:
+def upsert_doctrine_fits(doctrine_fit: DoctrineFit, remote: bool = False, db_alias: str = "wcmkt") -> None:
     """
     Upsert doctrine_fits entry keyed by fit_id.
     """
-    engine = _get_engine("wcmkt", remote)
+    engine = _get_engine(db_alias, remote)
     with engine.connect() as conn:
         existing = conn.execute(
             text("SELECT id FROM doctrine_fits WHERE fit_id = :fit_id"),
@@ -171,8 +171,8 @@ def upsert_doctrine_fits(doctrine_fit: DoctrineFit, remote: bool = False) -> Non
     logger.info(f"Upserted doctrine_fits for fit_id {doctrine_fit.fit_id}")
 
 
-def upsert_doctrine_map(doctrine_id: int, fit_id: int, remote: bool = False) -> None:
-    engine = _get_engine("wcmkt", remote)
+def upsert_doctrine_map(doctrine_id: int, fit_id: int, remote: bool = False, db_alias: str = "wcmkt") -> None:
+    engine = _get_engine(db_alias, remote)
     with engine.connect() as conn:
         exists = conn.execute(
             text("SELECT 1 FROM doctrine_map WHERE doctrine_id = :doctrine_id AND fitting_id = :fit_id"),
@@ -211,12 +211,12 @@ class DoctrineFitItems:
     def __post_init__(self):
         self.timestamp = datetime.datetime.strftime(datetime.datetime.now(datetime.timezone.utc), '%Y-%m-%d %H:%M:%S')
 
-def upsert_ship_target(fit_id: int, fit_name: str, ship_id: int, ship_name: str, ship_target: int, remote: bool = False) -> bool:
+def upsert_ship_target(fit_id: int, fit_name: str, ship_id: int, ship_name: str, ship_target: int, remote: bool = False, db_alias: str = "wcmkt") -> bool:
     """
     Upsert ship_targets entry keyed by fit_id.
     """
     created_at = datetime.datetime.strftime(datetime.datetime.now(datetime.timezone.utc), '%Y-%m-%d %H:%M:%S')
-    engine = _get_engine("wcmkt", remote)
+    engine = _get_engine(db_alias, remote)
     with engine.connect() as conn:
         stmt = text(
             """
@@ -447,7 +447,7 @@ def add_doctrine_type_info_to_watchlist(doctrine_id: int):
         logger.info(f"Added {type_info.type_name} to watchlist")
         print(f"Added {type_info.type_name} to watchlist")
 
-def refresh_doctrines_for_fit(fit_id: int, ship_id: int, ship_name: str, remote: bool = False) -> None:
+def refresh_doctrines_for_fit(fit_id: int, ship_id: int, ship_name: str, remote: bool = False, db_alias: str = "wcmkt") -> None:
     """
     Rebuild doctrines table rows for a fit based on fittings_fittingitem content.
     """
@@ -466,8 +466,8 @@ def refresh_doctrines_for_fit(fit_id: int, ship_id: int, ship_name: str, remote:
     if ship_id not in [c[0] for c in components]:
         components.append((ship_id, 1))
 
-    doctrines_engine = _get_engine("wcmkt", remote)
-    stats_engine = _get_engine("wcmkt", remote)
+    doctrines_engine = _get_engine(db_alias, remote)
+    stats_engine = _get_engine(db_alias, remote)
     timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat()
 
     # Pull market stats once into dict for quick lookup

--- a/src/mkts_backend/utils/doctrine_update.py
+++ b/src/mkts_backend/utils/doctrine_update.py
@@ -55,7 +55,10 @@ class DoctrineFit:
         with engine.connect() as conn:
             stmt = text("SELECT * FROM fittings_doctrine WHERE id = :doctrine_id")
             result = conn.execute(stmt, {"doctrine_id": self.doctrine_id})
-            name = result.fetchone()[1]
+            row = result.fetchone()
+            if row is None:
+                raise ValueError(f"Doctrine {self.doctrine_id} not found in fittings_doctrine")
+            name = row[1]
             return name.strip()
 
     def get_ship_type_id(self):
@@ -64,7 +67,10 @@ class DoctrineFit:
         with engine.connect() as conn:
             stmt = text("SELECT * FROM fittings_fitting WHERE id = :fit_id")
             result = conn.execute(stmt, {"fit_id": self.fit_id})
-            type_id = result.fetchone()[4]
+            row = result.fetchone()
+            if row is None:
+                raise ValueError(f"Fit {self.fit_id} not found in fittings_fitting")
+            type_id = row[4]
             return type_id
 
     def get_fit_name(self):
@@ -73,7 +79,10 @@ class DoctrineFit:
         with engine.connect() as conn:
             stmt = text("SELECT * FROM fittings_fitting WHERE id = :fit_id")
             result = conn.execute(stmt, {"fit_id": self.fit_id})
-            name = result.fetchone()[2]
+            row = result.fetchone()
+            if row is None:
+                raise ValueError(f"Fit {self.fit_id} not found in fittings_fitting")
+            name = row[2]
             return name.strip()
 
     def get_ship_name(self, remote=False):
@@ -82,7 +91,10 @@ class DoctrineFit:
         with engine.connect() as conn:
             stmt = text("SELECT * FROM inv_info WHERE typeID = :type_id")
             result = conn.execute(stmt, {"type_id": self.ship_type_id})
-            name = result.fetchone()[1]
+            row = result.fetchone()
+            if row is None:
+                raise ValueError(f"Ship type_id {self.ship_type_id} not found in inv_info")
+            name = row[1]
             return name.strip()
 
     def add_wcmkts2_doctrine_fits(self, remote=False):

--- a/src/mkts_backend/utils/doctrine_update.py
+++ b/src/mkts_backend/utils/doctrine_update.py
@@ -189,7 +189,7 @@ def upsert_doctrine_map(doctrine_id: int, fit_id: int, remote: bool = False, db_
     logger.info(f"Upserted doctrine_map entry doctrine_id={doctrine_id}, fit_id={fit_id}")
 
 @dataclass
-class DoctrineFitItems:
+class DoctrineComponent:
     fit_id: int
     ship_id: int
     ship_name: str
@@ -359,10 +359,10 @@ def add_lead_ship():
         print("Lead ship added")
     session.close()
 
-def process_hfi_fit_items(type_ids: list[int]) -> list[DoctrineFitItems]:
+def process_hfi_fit_items(type_ids: list[int]) -> list[DoctrineComponent]:
     items = []
     for type_id in type_ids:
-        item = DoctrineFitItems(
+        item = DoctrineComponent(
             fit_id=494,
             ship_id=33157,
             ship_name='Hurricane Fleet Issue',

--- a/src/mkts_backend/utils/parse_fits.py
+++ b/src/mkts_backend/utils/parse_fits.py
@@ -436,6 +436,7 @@ def update_fit_workflow(
     remote: bool = False,
     clear_existing: bool = True,
     dry_run: bool = False,
+    target_alias: str = "wcmkt",
 ):
     """
     End-to-end update for a fit:
@@ -473,8 +474,8 @@ def update_fit_workflow(
     doctrine_fit = DoctrineFit(doctrine_id=metadata.doctrine_id, fit_id=fit_id, target=metadata.target)
 
     # Propagate to market/production dbs
-    upsert_doctrine_fits(doctrine_fit, remote=remote)
-    upsert_doctrine_map(doctrine_fit.doctrine_id, doctrine_fit.fit_id, remote=remote)
+    upsert_doctrine_fits(doctrine_fit, remote=remote, db_alias=target_alias)
+    upsert_doctrine_map(doctrine_fit.doctrine_id, doctrine_fit.fit_id, remote=remote, db_alias=target_alias)
     upsert_ship_target(
         fit_id=doctrine_fit.fit_id,
         fit_name=doctrine_fit.fit_name,
@@ -482,18 +483,20 @@ def update_fit_workflow(
         ship_name=doctrine_fit.ship_name,
         ship_target=metadata.target,
         remote=remote,
+        db_alias=target_alias,
     )
     refresh_doctrines_for_fit(
         fit_id=doctrine_fit.fit_id,
         ship_id=doctrine_fit.ship_type_id,
         ship_name=doctrine_fit.ship_name,
         remote=remote,
+        db_alias=target_alias,
     )
 
     # Add missing items to watchlist in wcmkt
     type_ids = {item["type_id"] for item in parse_result.items}
     type_ids.add(ship_type_id)
-    add_missing_items_to_watchlist(list(type_ids), remote=remote)
+    add_missing_items_to_watchlist(list(type_ids), remote=remote, db_alias=target_alias)
     logger.info(
         f"Completed fit update for fit_id={fit_id}, doctrine_id={metadata.doctrine_id} (remote={remote})"
     )

--- a/src/mkts_backend/utils/parse_fits.py
+++ b/src/mkts_backend/utils/parse_fits.py
@@ -175,14 +175,14 @@ def parse_eft_fit_file(fit_file: str, fit_id: int, sde_engine) -> FitParseResult
                 if current_slot in {"LoSlot", "MedSlot", "HiSlot", "RigSlot"}:
                     suffix = slot_counters[current_slot]
                     slot_counters[current_slot] += 1
-                    slot_name = f\"{current_slot}{suffix}\"
+                    slot_name = f"{current_slot}{suffix}"
                 else:
                     slot_name = current_slot
 
                 type_id = _lookup_type_id(item_name, sde_conn)
                 if type_id is None:
                     missing.append(item_name)
-                    logger.warning(f\"Unable to resolve type_id for '{item_name}' (fit {fit_id})\")
+                    logger.warning(f"Unable to resolve type_id for '{item_name}' (fit {fit_id})")
                     continue
 
                 items.append(

--- a/src/mkts_backend/utils/parse_fits.py
+++ b/src/mkts_backend/utils/parse_fits.py
@@ -1,0 +1,284 @@
+import re
+from dataclasses import dataclass, field
+from typing import Optional, Generator
+from collections import defaultdict
+from datetime import datetime, timezone
+import json
+import pandas as pd
+from sqlalchemy import create_engine, text
+from mkts_backend.config.logging_config import configure_logging
+from mkts_backend.config import DatabaseConfig
+from mkts_backend.utils.doctrine_update import DoctrineFit
+from mkts_backend.utils.get_type_info import TypeInfo
+
+logger = configure_logging(__name__)
+
+db = DatabaseConfig("wcmkt")
+sde_db = DatabaseConfig("sde")
+fittings_db = DatabaseConfig("fittings")
+
+mkt_db = db.url
+sde_db = sde_db.url
+fittings_db = fittings_db.url
+
+
+@dataclass
+class FittingItem:
+    flag: str
+    quantity: int
+    fit_id: int
+    type_name: str
+    ship_type_name: str
+    fit_name: Optional[str] = None
+
+    type_id: int = field(init=False)
+    type_fk_id: int = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.type_id = self.get_type_id()
+        self.type_fk_id = self.type_id
+        self.details = self.get_fitting_details()
+        if "description" in self.details:
+            self.description = self.details['description']
+        else:
+            self.description = "No description"
+
+        if self.fit_name is None:
+            if "name" in self.details:
+                self.fit_name = self.details["name"]
+                if "name" in self.details and self.fit_name != self.details["name"]:
+                    logger.warning(
+                        f"Fit name mismatch: parsed='{self.fit_name}' vs DB='{self.details['name']}'"
+                    )
+            else:
+                self.fit_name = f"Default {self.ship_type_name} fit"
+
+    def get_type_id(self) -> int:
+        db = DatabaseConfig("sde")
+        engine = db.engine
+        query = text("SELECT typeID FROM inv_info WHERE typeName = :type_name")
+        with engine.connect() as conn:
+            result = conn.execute(query, {"type_name": self.type_name}).fetchone()
+            return result[0] if result else -1
+
+    def get_fitting_details(self) -> dict:
+        engine = create_engine(fittings_db, echo=False)
+        query = text("SELECT * FROM fittings_fitting WHERE id = :fit_id")
+        with engine.connect() as conn:
+            row = conn.execute(query, {"fit_id": self.fit_id}).fetchone()
+            return dict(row._mapping) if row else {}
+
+@dataclass
+class FitMetadata:
+    description: str
+    name: str
+    fit_id: int
+    doctrine_id: int
+    target: int
+    last_updated: datetime = field(init=False)
+    def __post_init__(self):
+        self.last_updated = datetime.now().astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def convert_fit_date(date: str) -> datetime:
+    dt = datetime.strptime("15 Jan 2025 19:12:04", "%d %b %Y %H:%M:%S")
+    return dt
+
+
+def slot_yielder() -> Generator[str, None, None]:
+    corrected_order = ['LoSlot', 'MedSlot', 'HiSlot', 'RigSlot', 'DroneBay']
+    for slot in corrected_order:
+        yield slot
+    while True:
+        yield 'Cargo'
+
+
+def process_fit(fit_file: str, fit_id: int):
+    fit = []
+    qty = 1
+    slot_gen = slot_yielder()
+    current_slot = None
+    ship_name = ""
+    fit_name = ""
+    slot_counters = defaultdict(int)
+
+    with open(fit_file, 'r', encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+
+            if line.startswith("[") and line.endswith("]"):
+                clean_name = line.strip('[]')
+                parts = clean_name.split(',')
+                ship_name = parts[0].strip()
+                fit_name = parts[1].strip() if len(parts) > 1 else "Unnamed Fit"
+                continue
+
+            if line == "":
+                current_slot = next(slot_gen)
+                continue
+
+            if current_slot is None:
+                current_slot = next(slot_gen)
+
+            qty_match = re.search(r'\s+x(\d+)$', line)
+            if qty_match:
+                qty = int(qty_match.group(1))
+                item = line[:qty_match.start()].strip()
+            else:
+                qty = 1
+                item = line.strip()
+
+            if current_slot in {'LoSlot', 'MedSlot', 'HiSlot', 'RigSlot'}:
+                suffix = slot_counters[current_slot]
+                slot_counters[current_slot] += 1
+                slot_name = f"{current_slot}{suffix}"
+            else:
+                slot_name = current_slot
+
+            fitting_item = FittingItem(
+                flag=slot_name,
+                fit_id=fit_id,
+                type_name=item,
+                ship_type_name=ship_name,
+                fit_name=fit_name,
+                quantity=qty,
+            )
+
+            fit.append([fitting_item.flag, fitting_item.quantity, fitting_item.type_id, fit_id, fitting_item.type_id])
+
+    return fit, ship_name, fit_name
+
+
+def add_doctrine_to_watch(doctrine_id: int, remote: bool = False) -> None:
+    """
+    Add a doctrine from fittings_doctrine to watch_doctrines table.
+
+    Args:
+        doctrine_id: The doctrine ID to copy from fittings_doctrine to watch_doctrines
+    """
+    db = DatabaseConfig("fittings")
+    engine = db.remote_engine if remote else db.engine
+
+    with engine.connect() as conn:
+        # Check if doctrine exists in fittings_doctrine
+        select_stmt = text("SELECT * FROM fittings_doctrine WHERE id = :doctrine_id")
+        result = conn.execute(select_stmt, {"doctrine_id": doctrine_id})
+        doctrine_row = result.fetchone()
+
+        if not doctrine_row:
+            logger.error(f"Doctrine {doctrine_id} not found in fittings_doctrine")
+            return
+
+        # Check if already exists in watch_doctrines
+        check_stmt = text("SELECT COUNT(*) FROM watch_doctrines WHERE id = :doctrine_id")
+        result = conn.execute(check_stmt, {"doctrine_id": doctrine_id})
+        count = result.fetchone()[0]
+
+        if count > 0:
+            logger.info(f"Doctrine {doctrine_id} already exists in watch_doctrines")
+            return
+
+        # Insert into watch_doctrines
+        insert_stmt = text("""
+            INSERT INTO watch_doctrines (id, name, icon_url, description, created, last_updated)
+            VALUES (:id, :name, :icon_url, :description, :created, :last_updated)
+        """)
+
+        conn.execute(insert_stmt, {
+            "id": doctrine_row[0],
+            "name": doctrine_row[1],
+            "icon_url": doctrine_row[2],
+            "description": doctrine_row[3],
+            "created": doctrine_row[4],
+            "last_updated": doctrine_row[5]
+        })
+        conn.commit()
+
+        logger.info(f"Added doctrine {doctrine_id} ('{doctrine_row[1]}') to watch_doctrines")
+
+    engine.dispose()
+
+
+def insert_fit_items_to_db(fit_items: list, fit_id: int, clear_existing: bool = True, remote: bool = False) -> None:
+    """
+    Insert parsed fit items into the fittings_fittingitem table.
+
+    Args:
+        fit_items: List of fit items where each item is [flag, quantity, type_id, fit_id, type_fk_id]
+        fit_id: The fit ID these items belong to
+        clear_existing: If True, delete existing items for this fit_id before inserting
+    """
+    db = DatabaseConfig("fittings")
+    engine = db.remote_engine if remote else db.engine
+
+    with engine.connect() as conn:
+        # Disable foreign key constraints for this transaction
+        conn.execute(text("PRAGMA foreign_keys = OFF"))
+
+        # Optionally clear existing items for this fit
+        if clear_existing:
+            delete_stmt = text("DELETE FROM fittings_fittingitem WHERE fit_id = :fit_id")
+            conn.execute(delete_stmt, {"fit_id": fit_id})
+            logger.info(f"Cleared existing items for fit_id {fit_id}")
+
+        # Insert new items
+        insert_stmt = text("""
+            INSERT INTO fittings_fittingitem (flag, quantity, type_id, fit_id, type_fk_id)
+            VALUES (:flag, :quantity, :type_id, :fit_id, :type_fk_id)
+        """)
+
+        for item in fit_items:
+            flag, quantity, type_id, fit_id, type_fk_id = item
+            conn.execute(insert_stmt, {
+                "flag": flag,
+                "quantity": quantity,
+                "type_id": type_id,
+                "fit_id": fit_id,
+                "type_fk_id": type_fk_id
+            })
+
+        conn.commit()
+
+        # Re-enable foreign key constraints
+        conn.execute(text("PRAGMA foreign_keys = ON"))
+
+        logger.info(f"Inserted {len(fit_items)} items for fit_id {fit_id}")
+
+    engine.dispose()
+
+def parse_fit_metadata(fit_metadata_file: str) -> FitMetadata:
+    with open(fit_metadata_file, 'r', encoding='utf-8') as f:
+        metadata = json.load(f)
+    return FitMetadata(**metadata)
+
+def update_fittings_fittting(FitMetadata: FitMetadata, remote: bool = False):
+    db = DatabaseConfig("fittings")
+    engine = db.remote_engine if remote else db.engine
+    with engine.connect() as conn:
+        stmt = text("UPDATE fittings_fitting SET description = :description, name = :name, last_updated = :last_updated WHERE id = :fit_id")
+        conn.execute(stmt, {"description": FitMetadata.description, "name": FitMetadata.name, "last_updated": FitMetadata.last_updated, "fit_id": FitMetadata.fit_id})
+        conn.commit()
+    conn.close()
+    engine.dispose()
+    logger.info(f"Updated fittings_fitting for fit_id {FitMetadata.fit_id}: {FitMetadata.description}, {FitMetadata.name}, {FitMetadata.last_updated}")
+
+def update_existing_fit(fit_id: int, fit_file: str, fit_metadata_file: str, remote: bool = False, clear_existing: bool = True):
+    fit, ship_name, fit_name = process_fit(fit_file, fit_id)
+    insert_fit_items_to_db(fit, fit_id=fit_id, clear_existing=clear_existing, remote=remote)
+    metadata = parse_fit_metadata(fit_metadata_file)
+    update_fittings_fittting(metadata, fit_id=fit_id, remote=remote)
+
+
+def update_fit(fit_id: int, fit_file: str, fit_metadata_file: str, remote: bool = False, clear_existing: bool = True):
+    fit, ship_name, fit_name = process_fit(fit_file, fit_id)
+    insert_fit_items_to_db(fit, fit_id=fit_id, clear_existing=clear_existing, remote=remote)
+    metadata = parse_fit_metadata(fit_metadata_file)
+    new_fit = DoctrineFit(doctrine_id=metadata.doctrine_id, fit_id=fit_id, target=metadata.target)
+    update_fittings_fittting(metadata, fit_id=fit_id, remote=remote)
+    #TODO: Update wcmktprod.doctrine_fits table
+    #TODO: Update wcmktprod.doctrines table
+    #TODO: Add any new items to wcmktprod.watchlist table
+    #TODO: Update wcmktprod.ship_targets table
+
+if __name__ == "__main__":
+    pass

--- a/src/mkts_backend/utils/parse_fits.py
+++ b/src/mkts_backend/utils/parse_fits.py
@@ -164,7 +164,7 @@ def parse_eft_fit_file(fit_file: str, fit_id: int, sde_engine) -> FitParseResult
                 if current_slot is None:
                     current_slot = next(slot_gen)
 
-                qty_match = re.search(r"\\s+x(\\d+)$", line)
+                qty_match = re.search(r"\s+x(\d+)$", line)
                 if qty_match:
                     qty = int(qty_match.group(1))
                     item_name = line[: qty_match.start()].strip()
@@ -187,11 +187,11 @@ def parse_eft_fit_file(fit_file: str, fit_id: int, sde_engine) -> FitParseResult
 
                 items.append(
                     {
-                        \"flag\": slot_name,
-                        \"quantity\": qty,
-                        \"type_id\": type_id,
-                        \"fit_id\": fit_id,
-                        \"type_fk_id\": type_id,
+                        "flag": slot_name,
+                        "quantity": qty,
+                        "type_id": type_id,
+                        "fit_id": fit_id,
+                        "type_fk_id": type_id,
                     }
                 )
 


### PR DESCRIPTION
## Summary
- add wcmktnorth alias/config and support Turso envs
- parameterize fit propagation and CLI update-fit to target north DB; adjust watchlist/doctrine upserts and ship_targets upsert to handle schema
- document usage and validate north update-fit (dry-run and real local)

## Test plan
- uv run mkts-backend update-fit --fit-file=new_zealot993.txt --meta-file=new_zealot_metadata.json --target=wcmktnorth --dry-run
- uv run mkts-backend update-fit --fit-file=new_zealot993.txt --meta-file=new_zealot_metadata.json --target=wcmktnorth

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a full EFT fit update pipeline with CLI support and north DB targeting, including upserts to fitting/doctrine tables and watchlist updates.
> 
> - **CLI**
>   - Add `update-fit` command with `--fit-file`, `--meta-file`, `--remote`, `--no-clear`, `--dry-run`, and target selection (`--target=wcmkt|wcmktnorth`/`--north`).
> - **Config/Settings**
>   - Introduce `wcmktnorth` alias with file paths and Turso envs in `settings.toml` and `DatabaseConfig`.
> - **Fit Update Pipeline**
>   - New `parse_fits.py` implementing end-to-end workflow:
>     - Parse EFT file to items; upsert `fittings_fitting` and `fittings_fittingitem` (with optional clear).
>     - Ensure link in `fittings_doctrine_fittings`.
>     - Upsert into target market DB: `doctrine_fits`, `doctrine_map`, `ship_targets` (delete-then-insert), and rebuild `doctrines` via marketstats.
>     - Add all involved type_ids to `watchlist` (parameterized DB alias); supports dry-run output.
> - **Doctrine utilities**
>   - `doctrine_update.py`: add upserts for `doctrine_fits`, `doctrine_map`, `ship_targets`; add `refresh_doctrines_for_fit` to rebuild `doctrines` per fit; minor dataclass/type renames.
> - **DB Models**
>   - Rename `DoctrineFit` model to `DoctrineFitItems` (same `doctrine_fits` table mapping).
> - **Utilities**
>   - `add_missing_items_to_watchlist` now accepts `db_alias` to target alternate market DBs.
>   - Add `utils/add2doctrines_table.py` for aggregating `fittings_fittingitem` into `doctrines` and maintenance helpers.
> - **Docs**
>   - Add `doctrine_update_feature.md` with goals, plan, and CLI usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ef5263928f14ca7e9a7defd4ec1fa2b509e65fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->