### PR TITLE
Doctrine tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,13 +218,16 @@ uv run fit-check --file=fit.txt --market=deployment
 uv run fit-check --file=fit.txt --target=50
 
 # Export to CSV
-uv run fit-check --file=fit.txt --export-csv=output.csv
+uv run fit-check --file=fit.txt --output=csv
 
 # Show multibuy format for restocking
-uv run fit-check --file=fit.txt --multibuy
+uv run fit-check --file=fit.txt --output=multibuy
+
+# Export markdown for Discord
+uv run fit-check --file=fit.txt --output=markdown
 
 # Combine options
-uv run fit-check --file=fit.txt --market=deployment --target=100 --export-csv=results.csv --multibuy
+uv run fit-check --file=fit.txt --market=deployment --target=100 --output=csv
 ```
 
 **Display Features:**
@@ -248,15 +251,23 @@ uv run fit-check --file=fit.txt --market=deployment --target=100 --export-csv=re
 - Displays "Qty Needed" column when target is available
 - Shows missing items list with quantities needed to reach target
 
-**Export Options:**
-- `--export-csv=<path>`: Exports the fit status table to CSV file for spreadsheet analysis
-- `--multibuy`: Displays items below target in Eve Multi-buy/jEveAssets stockpile format:
+**Export Options (`--output=<format>`):**
+- `csv`: Exports the fit status table to CSV file for spreadsheet analysis (auto-named from fit)
+- `multibuy`: Displays items below target in Eve Multi-buy/jEveAssets stockpile format:
   ```
   Damage Control II 15
   Gyrostabilizer II 30
   Large Shield Extender II 20
   ```
   This format can be copied directly into Eve Online or jEveAssets for easy restocking.
+- `markdown`: Discord-friendly markdown format with bold formatting for sharing fit status:
+  ```markdown
+  # Hurricane Fleet Issue
+  Target (**300**); Fits (**245**)
+
+  - **Damage Control II**: 165 needed (current: 245.0 fits)
+  - **Gyrostabilizer II**: 330 needed (current: 245.0 fits)
+  ```
 
 **Database Integration:**
 - Queries `marketstats` table for items on watchlist (uses pre-calculated pricing)

--- a/README.md
+++ b/README.md
@@ -98,10 +98,13 @@ uv run fit-check --file=fit.txt --market=deployment
 uv run fit-check --file=fit.txt --target=50
 
 # Export results to CSV
-uv run fit-check --file=fit.txt --export-csv=output.csv
+uv run fit-check --file=fit.txt --output=csv
 
 # Show multibuy format for restocking items below target
-uv run fit-check --file=fit.txt --multibuy
+uv run fit-check --file=fit.txt --output=multibuy
+
+# Export markdown for Discord sharing
+uv run fit-check --file=fit.txt --output=markdown
 
 # Read from stdin
 cat fit.txt | uv run fit-check --paste

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A comprehensive market data collection and analysis system for Eve Online that f
 - **Market Data Collection**: Fetches real-time market orders from Eve Online's ESI API
 - **Historical Analysis**: Collects and analyzes market history for trend analysis
 - **Doctrine Analysis**: Calculates ship fitting availability and market depth
+- **Fit Checking**: CLI tool to check market availability for ship fittings with export options
 - **Regional Processing**: Handles both structure-specific and region-wide market data
 - **Google Sheets Integration**: Automatically updates spreadsheets with market data
 - **Market Value Calculation**: Calculates total market value excluding blueprints/skills
@@ -80,6 +81,41 @@ uv run mkts-backend --history
 uv run mkts-backend --market=deployment --history
 ```
 
+## CLI Commands
+
+### fit-check - Check Market Availability for Ship Fittings
+
+Display market availability and pricing for ship fits from EFT-formatted files.
+
+```bash
+# Basic usage - check fit availability
+uv run fit-check --file=path/to/fit.txt
+
+# Check against specific market
+uv run fit-check --file=fit.txt --market=deployment
+
+# Override target quantity
+uv run fit-check --file=fit.txt --target=50
+
+# Export results to CSV
+uv run fit-check --file=fit.txt --export-csv=output.csv
+
+# Show multibuy format for restocking items below target
+uv run fit-check --file=fit.txt --multibuy
+
+# Read from stdin
+cat fit.txt | uv run fit-check --paste
+```
+
+**Features:**
+- Displays complete fit breakdown with market availability
+- Shows bottleneck items (lowest fits available)
+- Automatically retrieves target quantities from doctrine_fits table
+- Calculates quantity needed to reach target
+- Exports to CSV for spreadsheet analysis
+- Generates Eve Multi-buy format for easy restocking
+- Falls back to live market data for items not on watchlist
+
 ## Architecture
 
 ### Core Components
@@ -146,6 +182,10 @@ Configuration is managed through `settings.toml` with support for multiple marke
 - **`ship_targets`**: Ship production targets and goals
 - **`doctrine_map`**: Mapping between doctrines and fittings
 - **`doctrine_info`**: Doctrine metadata and information
+- **`doctrine_fits`**: Doctrine fitting configurations with target quantities
+  - Stores fit_name, ship_type_id, target quantity, and market_flag
+  - Used by fit-check command to retrieve target quantities
+  - Market flag indicates which markets track this doctrine (primary, deployment, both)
 
 ## API Integration
 

--- a/doctrine_tools.md
+++ b/doctrine_tools.md
@@ -24,9 +24,10 @@ A command-line interface that displays market availability for ship fittings fro
 - **Target Override**: `--target=N` parameter to override database target
 - **Fallback Pricing**: For items not on watchlist, queries `marketorders` table and calculates 5th percentile pricing
 - **Missing Items Report**: Shows items below target with quantity needed
-- **Export Options**:
-  - `--export-csv=<path>`: Export table to CSV file
-  - `--multibuy`: Display Eve Multi-buy/jEveAssets stockpile format for items below target
+- **Export Options** (`--output=<format>`):
+  - `csv`: Export table to CSV file (auto-named from fit)
+  - `multibuy`: Display Eve Multi-buy/jEveAssets stockpile format for items below target
+  - `markdown`: Discord-friendly markdown format with bold formatting
 
 ### CLI Usage:
 ```bash
@@ -40,10 +41,13 @@ fit-check --file=<path> --market=deployment
 fit-check --file=<path> --target=50
 
 # Export to CSV
-fit-check --file=<path> --export-csv=output.csv
+fit-check --file=<path> --output=csv
 
 # Show multibuy format for restocking
-fit-check --file=<path> --multibuy
+fit-check --file=<path> --output=multibuy
+
+# Export markdown for Discord
+fit-check --file=<path> --output=markdown
 
 # Read from stdin
 cat fit.txt | fit-check --paste

--- a/doctrine_tools.md
+++ b/doctrine_tools.md
@@ -1,0 +1,36 @@
+# Doctrine Tools CLI
+
+
+This update will expand the functionality of 'src/mkts-backend/utils/parse_fits.py' 
+
+It will add two new features:
+
+## Fit Check
+- Add a command line interface called fit-check that will display a table of market availability from the wcmkt db of fit items for an EFT formatted .txt (and if possible from a cut and paste in the cli.) 
+- It should take market as an argument: either primary or deployment. 
+- It should present a beautiful table that includes type_id, type_name, market_stock, fit_qty, (the quantity of the item required for each fit), fits (the number of fits that can be constructed based on the market_stock of the item), price (the market price of the item), fit_price (fit_qty * price) and avg_price (average price over 30 days). The header names should align with the schema of the marketstats table for simplicity. 
+- It should include a header with the name of the fit, ship_name, ship type id and the fit_cost (some of fit_price)
+- If the item is not on the watchlist, pricing information will not be available in the marketstats table in the wcmkt database. In this case, it should query the marketorder table to obtain the market information using similar logic to the calculate_market_stats() function, and execute an ESI api call to obtain the historical information. 
+- Use a cli library like Rich or other libraries that you think would be useful in creating a beautiful cli. 
+
+## Fit Update Tool
+Extend the update_fit_workflow() in parse_fits.py with an interactive interface that:
+- allows a user to add a new fit from an EFT formatted txt file or by pasting text in the cli (if possible). Reuse the functionality from Fit Check. It should update all appropriate database tables with the new fit information.
+- allows the user to create a new doctrine and choosing the fits that will be used with it interactively.
+- allows the user to input the fitting metadata in an interactive interface in the CLI or read it from a fit_metadata file. 
+- allows the user to update an existing fit from an EFT formatted fitting or interactively change elements of a fit. 
+- allows the user to assign the market that a new or existing fit will be assigned to. 
+- confirms the changes before committing them to the database.
+- there should be dry-run and local-only options for testing. 
+
+## Doctrine Market Assignment
+- Add functionality to configure which markets a doctrine will be tracked in: primary, secondary, or both.
+- This can be implemented with a simple flag in the doctrine_fits that can be read by the front end when determining which fits to display. 
+
+## Project Plan and Rules
+- First, create a plan that divides the implementation into several phases. Extend this file with your plan, and use it to track progress.
+- Write and execute tests prior to concluding each phase and document the work completed in this file. Include any information that a fresh instance of Claude will need to begin the next phase. 
+- Use sub-agents to make your work more efficient and preserve your context window. Deploy them concurrently when appropriate to allow faster progress. 
+- Call the documentation sub-agent as features are completed to update user and LLM documentation as features are completed. Check documentation at the end of each phase to see if any changes should be documented. 
+- IMPORTANT: Avoid complexity. Ensure that new features are implemented with simple solutions that are understandable and do not add unnecessary complexity. 
+- If an existing function is modified, be sure to write tests to confirm that 1) it continues to work properly after any changes and 2) that the new functionality works properly.

--- a/fits/maelstrom.txt
+++ b/fits/maelstrom.txt
@@ -14,7 +14,7 @@ Multispectrum Shield Hardener II
 Large Shield Extender II
 Medium F-RX Compact Capacitor Booster
 
-Heavy Gremlin Compact Energy Neutralizer
+Heavy Infectious Scoped Energy Neutralizer
 1400mm Howitzer Artillery II
 1400mm Howitzer Artillery II
 1400mm Howitzer Artillery II

--- a/fits/maelstrom.txt
+++ b/fits/maelstrom.txt
@@ -4,15 +4,15 @@ Damage Control II
 Gyrostabilizer II
 Gyrostabilizer II
 Gyrostabilizer II
-Tracking Enhancer II
+Power Diagnostic System II
 
-500MN Y-T8 Compact Microwarpdrive
+500MN Cold-Gas Enduring Microwarpdrive
 Large Shield Extender II
 EM Shield Hardener II
 Large Shield Extender II
-Multispectrum Shield Hardener II
 Large Shield Extender II
-Medium F-RX Compact Capacitor Booster
+Multispectrum Shield Hardener II
+Medium Capacitor Booster II
 
 Heavy Infectious Scoped Energy Neutralizer
 1400mm Howitzer Artillery II
@@ -43,7 +43,6 @@ Republic Fleet Nuclear L x400
 Republic Fleet Phased Plasma L x400
 Republic Fleet Proton L x250
 Republic Fleet Titanium Sabot L x400
-Inherent Implants 'Squire' Power Grid Management EG-602 x1
 Nanofiber Internal Structure II x2
-Power Diagnostic System II x1
 'Notos' Compact Large Proton Smartbomb x1
+Tracking Enhancer II x1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "sqlalchemy>=2.0.43",
     "libsql>=0.1.11",
     "python-dotenv>=1.1.1",
+    "rich>=13.0.0",
 ]
 
 [build-system]

--- a/src/mkts_backend/cli_tools/__init__.py
+++ b/src/mkts_backend/cli_tools/__init__.py
@@ -1,0 +1,12 @@
+"""
+CLI subpackage for mkts-backend doctrine tools.
+
+This package contains CLI commands for managing EVE Online fits and doctrines:
+- fit-check: Display market availability for EFT fits
+- fit-update: Interactive tool for managing fits and doctrines
+"""
+
+from mkts_backend.cli_tools.fit_check import fit_check_command
+from mkts_backend.cli_tools.fit_update import fit_update_command
+
+__all__ = ["fit_check_command", "fit_update_command"]

--- a/src/mkts_backend/cli_tools/fit_check.py
+++ b/src/mkts_backend/cli_tools/fit_check.py
@@ -443,20 +443,7 @@ def display_fit_status(
     # Get market data with target lookup
     result = get_fit_market_status(parse_result, market_ctx, target)
 
-    # Print header with target info
-    print_fit_header(
-        fit_name=result.fit_name,
-        ship_name=result.ship_name,
-        ship_type_id=result.ship_type_id,
-        market_name=result.market_name,
-        total_fit_cost=result.total_fit_cost,
-        total_fits=result.min_fits,
-        target=result.target,
-    )
-
-    console.print()
-
-    # Create and print table with qty_needed column
+    # Create table first to measure its width
     table = create_fit_status_table(
         fit_name=result.fit_name,
         ship_name=result.ship_name,
@@ -466,6 +453,25 @@ def display_fit_status(
         market_name=result.market_name,
         target=result.target,
     )
+
+    # Measure table width for header alignment
+    table_width = console.measure(table).maximum
+
+    # Print header with matching width
+    print_fit_header(
+        fit_name=result.fit_name,
+        ship_name=result.ship_name,
+        ship_type_id=result.ship_type_id,
+        market_name=result.market_name,
+        total_fit_cost=result.total_fit_cost,
+        total_fits=result.min_fits,
+        target=result.target,
+        width=table_width,
+    )
+
+    console.print()
+
+    # Print the table
     console.print(table)
 
     # Print summary

--- a/src/mkts_backend/cli_tools/fit_check.py
+++ b/src/mkts_backend/cli_tools/fit_check.py
@@ -1,0 +1,510 @@
+"""
+Fit Check CLI command.
+
+Displays market availability for items in an EFT-formatted ship fit.
+Uses Rich tables for beautiful console output.
+"""
+
+import csv
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from sqlalchemy import text
+
+from mkts_backend.config.logging_config import configure_logging
+from mkts_backend.config import DatabaseConfig
+from mkts_backend.config.market_context import MarketContext
+from mkts_backend.utils.eft_parser import parse_eft_file, parse_eft_string, FitParseResult
+from mkts_backend.cli_tools.rich_display import (
+    console,
+    create_fit_status_table,
+    print_fit_header,
+    print_fit_summary,
+    print_legend,
+    print_missing_for_target,
+    print_multibuy_export,
+)
+
+logger = configure_logging(__name__)
+
+
+@dataclass
+class FitCheckResult:
+    """Result of a fit check operation with market data and export utilities."""
+    fit_name: str
+    ship_name: str
+    ship_type_id: Optional[int]
+    market_data: List[Dict]
+    total_fit_cost: float
+    min_fits: float
+    target: Optional[int]
+    market_name: str
+
+    @property
+    def missing_for_target(self) -> List[Dict]:
+        """Get list of items that are below target with qty_needed."""
+        if self.target is None:
+            return []
+        return [
+            {
+                "type_name": item["type_name"],
+                "qty_needed": max(0, int((self.target - item["fits"]) * item["fit_qty"])),
+                "fits": item["fits"],
+            }
+            for item in self.market_data
+            if item["fits"] < self.target
+        ]
+
+    def to_csv(self, file_path: str) -> str:
+        """Export fit status table to CSV file."""
+        path = Path(file_path)
+        with open(path, "w", newline="") as f:
+            writer = csv.writer(f)
+            # Header
+            headers = ["type_id", "type_name", "market_stock", "fit_qty", "fits", "price", "fit_cost"]
+            if self.target is not None:
+                headers.append("qty_needed")
+            writer.writerow(headers)
+            # Data rows
+            for item in self.market_data:
+                row = [
+                    item.get("type_id", ""),
+                    item.get("type_name", ""),
+                    item.get("market_stock", 0),
+                    item.get("fit_qty", 1),
+                    f"{item.get('fits', 0):.1f}",
+                    f"{item.get('price', 0):.2f}" if item.get("price") else "",
+                    f"{item.get('fit_price', 0):.2f}",
+                ]
+                if self.target is not None:
+                    qty_needed = max(0, int((self.target - item["fits"]) * item["fit_qty"])) if item["fits"] < self.target else 0
+                    row.append(qty_needed)
+                writer.writerow(row)
+        return str(path.absolute())
+
+    def to_multibuy(self) -> str:
+        """Generate Eve Multi-buy/jEveAssets stockpile format for items below target."""
+        if self.target is None:
+            return ""
+        lines = []
+        for item in self.missing_for_target:
+            if item["qty_needed"] > 0:
+                lines.append(f"{item['type_name']} {item['qty_needed']}")
+        return "\n".join(lines)
+
+
+def _get_target_for_fit(
+    fit_name: str,
+    ship_type_id: Optional[int] = None,
+    market_ctx: Optional[MarketContext] = None,
+) -> Optional[int]:
+    """
+    Look up target quantity from doctrine_fits table.
+
+    Args:
+        fit_name: Name of the fit to look up
+        ship_type_id: Ship type ID (used as fallback lookup)
+        market_ctx: Market context for database selection
+
+    Returns:
+        Target quantity if found, None otherwise
+    """
+    db_alias = market_ctx.database_alias if market_ctx else "wcmkt"
+    db = DatabaseConfig(db_alias)
+
+    with db.engine.connect() as conn:
+        # Try exact fit name match first
+        query = text("""
+            SELECT target FROM doctrine_fits
+            WHERE fit_name = :fit_name
+            LIMIT 1
+        """)
+        result = conn.execute(query, {"fit_name": fit_name}).fetchone()
+        if result:
+            return result[0]
+
+        # Try ship_type_id match as fallback
+        if ship_type_id:
+            query = text("""
+                SELECT target FROM doctrine_fits
+                WHERE ship_type_id = :ship_type_id
+                LIMIT 1
+            """)
+            result = conn.execute(query, {"ship_type_id": ship_type_id}).fetchone()
+            if result:
+                return result[0]
+
+    return None
+
+
+def _get_marketstats_data(
+    type_ids: List[int],
+    market_ctx: Optional[MarketContext] = None,
+) -> Dict[int, Dict]:
+    """
+    Query marketstats table for items on the watchlist.
+
+    Args:
+        type_ids: List of type IDs to query
+        market_ctx: Market context for database selection
+
+    Returns:
+        Dict mapping type_id to market stats data
+    """
+    db_alias = market_ctx.database_alias if market_ctx else "wcmkt"
+    db = DatabaseConfig(db_alias)
+
+    results = {}
+    with db.engine.connect() as conn:
+        for type_id in type_ids:
+            query = text("""
+                SELECT type_id, type_name, price, min_price, total_volume_remain,
+                       avg_price, avg_volume, days_remaining, last_update
+                FROM marketstats
+                WHERE type_id = :type_id
+            """)
+            row = conn.execute(query, {"type_id": type_id}).fetchone()
+            if row:
+                results[type_id] = dict(row._mapping)
+
+    return results
+
+
+def _get_fallback_data(
+    type_id: int,
+    market_ctx: Optional[MarketContext] = None,
+) -> Optional[Dict]:
+    """
+    Get market data from marketorders for items not on watchlist.
+
+    Calculates 5th percentile price from current sell orders.
+
+    Args:
+        type_id: Type ID to query
+        market_ctx: Market context for database selection
+
+    Returns:
+        Dict with calculated price data, or None if no orders found
+    """
+    db_alias = market_ctx.database_alias if market_ctx else "wcmkt"
+    db = DatabaseConfig(db_alias)
+
+    with db.engine.connect() as conn:
+        # Get sell orders sorted by price (lowest first)
+        query = text("""
+            SELECT price, volume_remain
+            FROM marketorders
+            WHERE type_id = :type_id AND is_buy_order = 0
+            ORDER BY price ASC
+        """)
+        rows = conn.execute(query, {"type_id": type_id}).fetchall()
+
+        if not rows:
+            return None
+
+        # Calculate total volume and 5th percentile price
+        prices = []
+        volumes = []
+        for row in rows:
+            prices.append(row.price)
+            volumes.append(row.volume_remain)
+
+        total_volume = sum(volumes)
+
+        # Calculate 5th percentile price (price where 5% of volume is below)
+        if total_volume > 0:
+            target_volume = total_volume * 0.05
+            cumulative = 0
+            percentile_5_price = prices[0]
+
+            for price, volume in zip(prices, volumes):
+                cumulative += volume
+                if cumulative >= target_volume:
+                    percentile_5_price = price
+                    break
+
+            return {
+                "type_id": type_id,
+                "price": percentile_5_price,
+                "min_price": prices[0] if prices else None,
+                "total_volume_remain": total_volume,
+                "avg_price": sum(p * v for p, v in zip(prices, volumes)) / total_volume if total_volume else None,
+                "is_fallback": True,
+            }
+
+    return None
+
+
+def _get_type_name_from_sde(type_id: int) -> str:
+    """Get type name from SDE database."""
+    sde_db = DatabaseConfig("sde")
+    with sde_db.engine.connect() as conn:
+        query = text("SELECT typeName FROM inv_info WHERE typeID = :type_id")
+        result = conn.execute(query, {"type_id": type_id}).fetchone()
+        return result[0] if result else f"Unknown (ID: {type_id})"
+
+
+def get_fit_market_status(
+    parse_result: FitParseResult,
+    market_ctx: Optional[MarketContext] = None,
+    target: Optional[int] = None,
+) -> FitCheckResult:
+    """
+    Get market status for all items in a parsed fit.
+
+    Args:
+        parse_result: Parsed EFT fit result
+        market_ctx: Market context for database selection
+        target: Optional target quantity override. If None, looks up from doctrine_fits.
+
+    Returns:
+        FitCheckResult with market data and export utilities
+    """
+    market_name = market_ctx.name if market_ctx else "primary"
+
+    # Look up target from doctrine_fits if not provided
+    if target is None:
+        target = _get_target_for_fit(
+            parse_result.fit_name,
+            parse_result.ship_type_id,
+            market_ctx,
+        )
+    # Aggregate items by type_id
+    item_quantities = defaultdict(int)
+    item_names = {}
+    for item in parse_result.items:
+        type_id = item["type_id"]
+        item_quantities[type_id] += item["quantity"]
+        if type_id not in item_names:
+            item_names[type_id] = item.get("type_name", "")
+
+    # Add ship hull
+    if parse_result.ship_type_id:
+        if parse_result.ship_type_id not in item_quantities:
+            item_quantities[parse_result.ship_type_id] = 1
+            item_names[parse_result.ship_type_id] = parse_result.ship_name
+
+    type_ids = list(item_quantities.keys())
+
+    # Get marketstats data
+    marketstats_data = _get_marketstats_data(type_ids, market_ctx)
+
+    # Build result list
+    market_data = []
+    for type_id, fit_qty in item_quantities.items():
+        if type_id in marketstats_data:
+            stats = marketstats_data[type_id]
+            market_stock = stats.get("total_volume_remain", 0) or 0
+            price = stats.get("price")
+            avg_price = stats.get("avg_price")
+            is_fallback = False
+            type_name = stats.get("type_name", item_names.get(type_id, ""))
+        else:
+            # Try fallback from marketorders
+            fallback = _get_fallback_data(type_id, market_ctx)
+            if fallback:
+                market_stock = fallback.get("total_volume_remain", 0) or 0
+                price = fallback.get("price")
+                avg_price = fallback.get("avg_price")
+                is_fallback = True
+            else:
+                market_stock = 0
+                price = None
+                avg_price = None
+                is_fallback = True
+
+            # Get type name from SDE if not in item_names
+            type_name = item_names.get(type_id) or _get_type_name_from_sde(type_id)
+
+        # Calculate fits available
+        fits = (market_stock / fit_qty) if fit_qty > 0 else 0
+
+        # Calculate fit cost
+        fit_price = (price * fit_qty) if price else 0
+
+        market_data.append({
+            "type_id": type_id,
+            "type_name": type_name,
+            "market_stock": market_stock,
+            "fit_qty": fit_qty,
+            "fits": fits,
+            "price": price,
+            "fit_price": fit_price,
+            "avg_price": avg_price,
+            "is_fallback": is_fallback,
+        })
+
+    # Sort by fits available (lowest first to highlight bottlenecks)
+    market_data.sort(key=lambda x: (x["fits"], x["type_name"]))
+
+    # Calculate totals
+    total_fit_cost = sum(item.get("fit_price", 0) for item in market_data)
+    min_fits = min((item["fits"] for item in market_data), default=0)
+
+    return FitCheckResult(
+        fit_name=parse_result.fit_name,
+        ship_name=parse_result.ship_name,
+        ship_type_id=parse_result.ship_type_id,
+        market_data=market_data,
+        total_fit_cost=total_fit_cost,
+        min_fits=min_fits,
+        target=target,
+        market_name=market_name,
+    )
+
+
+def display_fit_status(
+    parse_result: FitParseResult,
+    market_ctx: Optional[MarketContext] = None,
+    show_legend: bool = True,
+    target: Optional[int] = None,
+    export_csv: Optional[str] = None,
+    show_multibuy: bool = False,
+) -> FitCheckResult:
+    """
+    Display market status for a parsed fit using Rich formatting.
+
+    Args:
+        parse_result: Parsed EFT fit result
+        market_ctx: Market context for database selection
+        show_legend: Whether to show the legend
+        target: Optional target quantity override
+        export_csv: Path to export CSV file (if provided)
+        show_multibuy: Whether to show multi-buy export text
+
+    Returns:
+        FitCheckResult object with market data
+    """
+    # Get market data with target lookup
+    result = get_fit_market_status(parse_result, market_ctx, target)
+
+    # Print header with target info
+    print_fit_header(
+        fit_name=result.fit_name,
+        ship_name=result.ship_name,
+        ship_type_id=result.ship_type_id,
+        market_name=result.market_name,
+        total_fit_cost=result.total_fit_cost,
+        total_fits=result.min_fits,
+        target=result.target,
+    )
+
+    console.print()
+
+    # Create and print table with qty_needed column
+    table = create_fit_status_table(
+        fit_name=result.fit_name,
+        ship_name=result.ship_name,
+        ship_type_id=result.ship_type_id,
+        market_data=result.market_data,
+        total_fit_cost=result.total_fit_cost,
+        market_name=result.market_name,
+        target=result.target,
+    )
+    console.print(table)
+
+    # Print summary
+    available_count = sum(1 for item in result.market_data if item["fits"] >= 1)
+    total_count = len(result.market_data)
+    missing_items = [item["type_name"] for item in result.market_data if item["fits"] < 1]
+
+    print_fit_summary(
+        available_count=available_count,
+        total_count=total_count,
+        min_fits=result.min_fits,
+        missing_items=missing_items,
+    )
+
+    # Print missing modules for target
+    if result.target is not None and result.missing_for_target:
+        print_missing_for_target(result.missing_for_target, result.target)
+
+    if show_legend:
+        print_legend()
+
+    # Handle exports
+    if export_csv:
+        csv_path = result.to_csv(export_csv)
+        console.print(f"\n[green]CSV exported to:[/green] {csv_path}")
+
+    if show_multibuy:
+        multibuy_text = result.to_multibuy()
+        if multibuy_text:
+            print_multibuy_export(multibuy_text)
+        else:
+            console.print("\n[yellow]No items below target - nothing to export for multi-buy[/yellow]")
+
+    return result
+
+
+def fit_check_command(
+    file_path: Optional[str] = None,
+    eft_text: Optional[str] = None,
+    market_alias: str = "primary",
+    show_legend: bool = True,
+    target: Optional[int] = None,
+    export_csv: Optional[str] = None,
+    show_multibuy: bool = False,
+) -> bool:
+    """
+    Execute the fit-check command.
+
+    Args:
+        file_path: Path to EFT fit file
+        eft_text: Raw EFT text (alternative to file)
+        market_alias: Market alias (primary, deployment)
+        show_legend: Whether to show the legend
+        target: Optional target quantity override
+        export_csv: Path to export CSV file
+        show_multibuy: Whether to show multi-buy export text
+
+    Returns:
+        True if successful, False otherwise
+    """
+    try:
+        # Get market context
+        market_ctx = MarketContext.from_settings(market_alias)
+    except ValueError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        console.print(f"Available markets: {', '.join(MarketContext.list_available())}")
+        return False
+
+    # Parse fit
+    try:
+        if file_path:
+            parse_result = parse_eft_file(file_path)
+        elif eft_text:
+            parse_result = parse_eft_string(eft_text)
+        else:
+            console.print("[red]Error: Either --file or --paste must be specified[/red]")
+            return False
+    except FileNotFoundError:
+        console.print(f"[red]Error: File not found: {file_path}[/red]")
+        return False
+    except Exception as e:
+        console.print(f"[red]Error parsing fit: {e}[/red]")
+        logger.exception("Error parsing EFT fit")
+        return False
+
+    # Check for missing types
+    if parse_result.has_missing_types:
+        console.print("[yellow]Warning: Some items could not be resolved:[/yellow]")
+        for item in parse_result.missing_types[:5]:
+            console.print(f"  • {item}", style="yellow")
+        if len(parse_result.missing_types) > 5:
+            console.print(f"  ... and {len(parse_result.missing_types) - 5} more", style="dim yellow")
+        console.print()
+
+    # Display status
+    display_fit_status(
+        parse_result,
+        market_ctx,
+        show_legend=show_legend,
+        target=target,
+        export_csv=export_csv,
+        show_multibuy=show_multibuy,
+    )
+
+    return True

--- a/src/mkts_backend/cli_tools/fit_update.py
+++ b/src/mkts_backend/cli_tools/fit_update.py
@@ -1,0 +1,495 @@
+"""
+Fit Update CLI commands.
+
+Interactive tools for managing fits and doctrines:
+- add: Add a new fit with optional interactive metadata prompts
+- update: Update an existing fit
+- assign-market: Assign market flags to fits
+- list-fits: List all fits
+- list-doctrines: List all doctrines
+- create-doctrine: Create a new doctrine
+"""
+
+from typing import List, Optional
+from rich.console import Console
+from rich.table import Table
+from rich.panel import Panel
+from rich.prompt import Prompt, Confirm, IntPrompt
+from rich import box
+from sqlalchemy import text
+
+from mkts_backend.config.logging_config import configure_logging
+from mkts_backend.config import DatabaseConfig
+from mkts_backend.utils.eft_parser import parse_eft_file, FitParseResult
+from mkts_backend.utils.doctrine_update import (
+    update_fit_market_flag,
+    get_fit_market_flag,
+)
+from mkts_backend.utils.parse_fits import update_fit_workflow, parse_fit_metadata, FitMetadata
+from mkts_backend.cli_tools.fit_check import display_fit_status
+
+logger = configure_logging(__name__)
+console = Console()
+
+
+def get_available_doctrines(remote: bool = False) -> List[dict]:
+    """Get list of available doctrines from fittings database."""
+    db = DatabaseConfig("fittings")
+    engine = db.remote_engine if remote else db.engine
+
+    doctrines = []
+    with engine.connect() as conn:
+        result = conn.execute(text("SELECT id, name, description FROM fittings_doctrine ORDER BY name"))
+        for row in result:
+            doctrines.append({
+                "id": row[0],
+                "name": row[1],
+                "description": row[2] or "",
+            })
+
+    engine.dispose()
+    return doctrines
+
+
+def get_fits_list(db_alias: str = "wcmkt", remote: bool = False) -> List[dict]:
+    """Get list of fits from doctrine_fits table."""
+    db = DatabaseConfig(db_alias)
+    engine = db.remote_engine if remote else db.engine
+
+    fits = []
+    with engine.connect() as conn:
+        # Check if market_flag column exists
+        try:
+            result = conn.execute(text("""
+                SELECT fit_id, fit_name, ship_name, doctrine_name, target, market_flag
+                FROM doctrine_fits
+                ORDER BY doctrine_name, fit_name
+            """))
+            has_market_flag = True
+        except Exception:
+            # Fallback query without market_flag
+            result = conn.execute(text("""
+                SELECT fit_id, fit_name, ship_name, doctrine_name, target
+                FROM doctrine_fits
+                ORDER BY doctrine_name, fit_name
+            """))
+            has_market_flag = False
+
+        for row in result:
+            fits.append({
+                "fit_id": row[0],
+                "fit_name": row[1],
+                "ship_name": row[2],
+                "doctrine_name": row[3],
+                "target": row[4],
+                "market_flag": row[5] if has_market_flag and len(row) > 5 else "primary",
+            })
+
+    engine.dispose()
+    return fits
+
+
+def display_fits_table(fits: List[dict]) -> None:
+    """Display fits in a Rich table."""
+    table = Table(
+        title="[bold cyan]Doctrine Fits[/bold cyan]",
+        box=box.ROUNDED,
+        show_header=True,
+        header_style="bold magenta",
+    )
+
+    table.add_column("Fit ID", style="dim", justify="right", width=8)
+    table.add_column("Fit Name", style="white", min_width=30)
+    table.add_column("Ship", style="cyan", min_width=20)
+    table.add_column("Doctrine", style="green", min_width=20)
+    table.add_column("Target", justify="right", width=8)
+    table.add_column("Market", justify="center", width=12)
+
+    for fit in fits:
+        market_style = {
+            "primary": "green",
+            "deployment": "yellow",
+            "both": "blue",
+        }.get(fit["market_flag"], "white")
+
+        table.add_row(
+            str(fit["fit_id"]),
+            fit["fit_name"],
+            fit["ship_name"],
+            fit["doctrine_name"],
+            str(fit["target"]),
+            f"[{market_style}]{fit['market_flag']}[/{market_style}]",
+        )
+
+    console.print(table)
+
+
+def display_doctrines_table(doctrines: List[dict]) -> None:
+    """Display doctrines in a Rich table."""
+    table = Table(
+        title="[bold cyan]Available Doctrines[/bold cyan]",
+        box=box.ROUNDED,
+        show_header=True,
+        header_style="bold magenta",
+    )
+
+    table.add_column("ID", style="dim", justify="right", width=6)
+    table.add_column("Name", style="white", min_width=30)
+    table.add_column("Description", style="dim", min_width=40)
+
+    for doctrine in doctrines:
+        desc = doctrine["description"][:50] + "..." if len(doctrine["description"]) > 50 else doctrine["description"]
+        table.add_row(
+            str(doctrine["id"]),
+            doctrine["name"],
+            desc,
+        )
+
+    console.print(table)
+
+
+def interactive_add_fit(
+    fit_file: str,
+    remote: bool = False,
+    dry_run: bool = False,
+    target_alias: str = "wcmkt",
+    market_flag: str = "primary",
+) -> bool:
+    """
+    Interactively add a new fit with prompts for metadata.
+
+    Args:
+        fit_file: Path to EFT fit file
+        remote: Use remote database
+        dry_run: Preview without committing
+        target_alias: Target database alias
+        market_flag: Market assignment
+
+    Returns:
+        True if successful
+    """
+    # Parse the fit file first
+    try:
+        parse_result = parse_eft_file(fit_file)
+    except FileNotFoundError:
+        console.print(f"[red]Error: File not found: {fit_file}[/red]")
+        return False
+    except Exception as e:
+        console.print(f"[red]Error parsing fit: {e}[/red]")
+        return False
+
+    # Display parsed fit info
+    console.print(Panel(
+        f"[bold]Ship:[/bold] {parse_result.ship_name}\n"
+        f"[bold]Fit Name:[/bold] {parse_result.fit_name}\n"
+        f"[bold]Items:[/bold] {len(parse_result.items)}",
+        title="[bold cyan]Parsed Fit[/bold cyan]",
+        border_style="blue",
+    ))
+
+    if parse_result.has_missing_types:
+        console.print("[yellow]Warning: Some items could not be resolved:[/yellow]")
+        for item in parse_result.missing_types[:5]:
+            console.print(f"  • {item}", style="yellow")
+        if not Confirm.ask("Continue anyway?"):
+            return False
+
+    # Get fit description
+    description = Prompt.ask(
+        "[bold]Fit description[/bold]",
+        default=f"{parse_result.fit_name} for {parse_result.ship_name}"
+    )
+
+    # Show available doctrines and select
+    doctrines = get_available_doctrines(remote=remote)
+    if doctrines:
+        console.print()
+        display_doctrines_table(doctrines)
+        console.print()
+
+        doctrine_input = Prompt.ask(
+            "[bold]Doctrine ID(s)[/bold] (comma-separated for multiple)",
+            default=""
+        )
+        if doctrine_input:
+            doctrine_ids = [int(d.strip()) for d in doctrine_input.split(",") if d.strip()]
+        else:
+            console.print("[yellow]Warning: No doctrine selected[/yellow]")
+            if not Confirm.ask("Continue without doctrine assignment?"):
+                return False
+            doctrine_ids = []
+    else:
+        console.print("[yellow]No doctrines found in database[/yellow]")
+        doctrine_ids = []
+
+    # Get target quantity
+    target = IntPrompt.ask("[bold]Target quantity[/bold]", default=100)
+
+    # Get fit ID
+    fit_id = IntPrompt.ask("[bold]Fit ID[/bold] (unique identifier)")
+
+    # Market assignment
+    market_choices = ["primary", "deployment", "both"]
+    market_flag = Prompt.ask(
+        "[bold]Market assignment[/bold]",
+        choices=market_choices,
+        default=market_flag
+    )
+
+    # Show summary
+    console.print()
+    console.print(Panel(
+        f"[bold]Fit ID:[/bold] {fit_id}\n"
+        f"[bold]Name:[/bold] {parse_result.fit_name}\n"
+        f"[bold]Ship:[/bold] {parse_result.ship_name}\n"
+        f"[bold]Description:[/bold] {description}\n"
+        f"[bold]Doctrine(s):[/bold] {doctrine_ids or 'None'}\n"
+        f"[bold]Target:[/bold] {target}\n"
+        f"[bold]Market:[/bold] {market_flag}\n"
+        f"[bold]Remote:[/bold] {remote}\n"
+        f"[bold]Database:[/bold] {target_alias}",
+        title="[bold green]Fit Summary[/bold green]",
+        border_style="green",
+    ))
+
+    if dry_run:
+        console.print("[yellow]DRY RUN - No changes will be made[/yellow]")
+        return True
+
+    if not Confirm.ask("Proceed with adding this fit?"):
+        console.print("[yellow]Cancelled[/yellow]")
+        return False
+
+    # Create temporary metadata file for the workflow
+    import json
+    import tempfile
+    import os
+
+    metadata = {
+        "fit_id": fit_id,
+        "name": parse_result.fit_name,
+        "description": description,
+        "doctrine_id": doctrine_ids if len(doctrine_ids) > 1 else (doctrine_ids[0] if doctrine_ids else 1),
+        "target": target,
+    }
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+        json.dump(metadata, f)
+        meta_path = f.name
+
+    try:
+        # Call the existing workflow
+        update_fit_workflow(
+            fit_id=fit_id,
+            fit_file=fit_file,
+            fit_metadata_file=meta_path,
+            remote=remote,
+            clear_existing=True,
+            dry_run=False,
+            target_alias=target_alias,
+        )
+
+        # Update market flag if needed
+        if market_flag != "primary":
+            update_fit_market_flag(fit_id, market_flag, remote=remote, db_alias=target_alias)
+
+        console.print(f"[green]Successfully added fit {fit_id}[/green]")
+        return True
+
+    except Exception as e:
+        console.print(f"[red]Error adding fit: {e}[/red]")
+        logger.exception("Error in interactive_add_fit")
+        return False
+
+    finally:
+        os.unlink(meta_path)
+
+
+def assign_market_command(
+    fit_id: int,
+    market_flag: str,
+    remote: bool = False,
+    db_alias: str = "wcmkt",
+) -> bool:
+    """
+    Assign a market flag to a fit.
+
+    Args:
+        fit_id: The fit ID to update
+        market_flag: New market assignment
+        remote: Use remote database
+        db_alias: Database alias
+
+    Returns:
+        True if successful
+    """
+    try:
+        success = update_fit_market_flag(fit_id, market_flag, remote=remote, db_alias=db_alias)
+        if success:
+            console.print(f"[green]Successfully updated fit {fit_id} to market '{market_flag}'[/green]")
+        else:
+            console.print(f"[yellow]No fit found with ID {fit_id}[/yellow]")
+        return success
+    except ValueError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        return False
+    except Exception as e:
+        console.print(f"[red]Error updating market flag: {e}[/red]")
+        logger.exception("Error in assign_market_command")
+        return False
+
+
+def list_fits_command(db_alias: str = "wcmkt", remote: bool = False) -> None:
+    """List all fits in the doctrine_fits table."""
+    fits = get_fits_list(db_alias=db_alias, remote=remote)
+    if fits:
+        display_fits_table(fits)
+        console.print(f"\n[dim]Total: {len(fits)} fits[/dim]")
+    else:
+        console.print("[yellow]No fits found[/yellow]")
+
+
+def list_doctrines_command(remote: bool = False) -> None:
+    """List all available doctrines."""
+    doctrines = get_available_doctrines(remote=remote)
+    if doctrines:
+        display_doctrines_table(doctrines)
+        console.print(f"\n[dim]Total: {len(doctrines)} doctrines[/dim]")
+    else:
+        console.print("[yellow]No doctrines found[/yellow]")
+
+
+def fit_update_command(
+    subcommand: str,
+    fit_id: Optional[int] = None,
+    file_path: Optional[str] = None,
+    meta_file: Optional[str] = None,
+    market_flag: str = "primary",
+    remote: bool = False,
+    local_only: bool = False,
+    dry_run: bool = False,
+    interactive: bool = False,
+    target_alias: str = "wcmkt",
+) -> bool:
+    """
+    Main entry point for fit-update commands.
+
+    Args:
+        subcommand: The subcommand to run (add, update, assign-market, list-fits, list-doctrines)
+        fit_id: Fit ID for update/assign-market commands
+        file_path: Path to EFT fit file
+        meta_file: Path to metadata JSON file
+        market_flag: Market assignment
+        remote: Use remote database
+        local_only: Use local database only (no Turso sync)
+        dry_run: Preview without committing
+        interactive: Use interactive prompts
+        target_alias: Target database alias
+
+    Returns:
+        True if command succeeded
+    """
+    # Determine remote flag
+    use_remote = remote and not local_only
+
+    if subcommand == "list-fits":
+        list_fits_command(db_alias=target_alias, remote=use_remote)
+        return True
+
+    elif subcommand == "list-doctrines":
+        list_doctrines_command(remote=use_remote)
+        return True
+
+    elif subcommand == "assign-market":
+        if fit_id is None:
+            console.print("[red]Error: --fit-id is required for assign-market[/red]")
+            return False
+        return assign_market_command(fit_id, market_flag, remote=use_remote, db_alias=target_alias)
+
+    elif subcommand == "add":
+        if not file_path:
+            console.print("[red]Error: --file is required for add command[/red]")
+            return False
+
+        if interactive:
+            return interactive_add_fit(
+                fit_file=file_path,
+                remote=use_remote,
+                dry_run=dry_run,
+                target_alias=target_alias,
+                market_flag=market_flag,
+            )
+        else:
+            if not meta_file:
+                console.print("[red]Error: --meta-file is required for non-interactive add[/red]")
+                console.print("[dim]Use --interactive for prompted input[/dim]")
+                return False
+
+            try:
+                metadata = parse_fit_metadata(meta_file)
+                result = update_fit_workflow(
+                    fit_id=metadata.fit_id,
+                    fit_file=file_path,
+                    fit_metadata_file=meta_file,
+                    remote=use_remote,
+                    clear_existing=True,
+                    dry_run=dry_run,
+                    target_alias=target_alias,
+                )
+
+                if dry_run:
+                    console.print("[yellow]DRY RUN complete[/yellow]")
+                    console.print(f"Ship: {result['ship_name']} ({result['ship_type_id']})")
+                    console.print(f"Items: {len(result['items'])}")
+                else:
+                    console.print(f"[green]Successfully added fit {metadata.fit_id}[/green]")
+
+                return True
+
+            except Exception as e:
+                console.print(f"[red]Error: {e}[/red]")
+                logger.exception("Error in fit_update_command add")
+                return False
+
+    elif subcommand == "update":
+        if fit_id is None:
+            console.print("[red]Error: --fit-id is required for update command[/red]")
+            return False
+        if not file_path:
+            console.print("[red]Error: --file is required for update command[/red]")
+            return False
+
+        # For update, we need a metadata file
+        if not meta_file:
+            console.print("[red]Error: --meta-file is required for update command[/red]")
+            return False
+
+        try:
+            result = update_fit_workflow(
+                fit_id=fit_id,
+                fit_file=file_path,
+                fit_metadata_file=meta_file,
+                remote=use_remote,
+                clear_existing=True,
+                dry_run=dry_run,
+                target_alias=target_alias,
+            )
+
+            if dry_run:
+                console.print("[yellow]DRY RUN complete[/yellow]")
+                console.print(f"Ship: {result['ship_name']} ({result['ship_type_id']})")
+                console.print(f"Items: {len(result['items'])}")
+            else:
+                console.print(f"[green]Successfully updated fit {fit_id}[/green]")
+
+            return True
+
+        except Exception as e:
+            console.print(f"[red]Error: {e}[/red]")
+            logger.exception("Error in fit_update_command update")
+            return False
+
+    else:
+        console.print(f"[red]Unknown subcommand: {subcommand}[/red]")
+        console.print("[dim]Available: add, update, assign-market, list-fits, list-doctrines[/dim]")
+        return False

--- a/src/mkts_backend/cli_tools/rich_display.py
+++ b/src/mkts_backend/cli_tools/rich_display.py
@@ -285,7 +285,7 @@ def print_missing_for_target(missing_items: List[Dict], target: int) -> None:
 
 def print_multibuy_export(multibuy_text: str) -> None:
     """
-    Print the multi-buy export text in a panel for easy copying.
+    Print the multi-buy export text as plain text for easy copying.
 
     Args:
         multibuy_text: Multi-buy format text to display
@@ -294,11 +294,28 @@ def print_multibuy_export(multibuy_text: str) -> None:
         return
 
     console.print()
-    panel = Panel(
-        multibuy_text,
-        title="[bold]Eve Multi-buy / jEveAssets Stockpile Format[/bold]",
-        subtitle="[dim]Copy and paste into game or tool[/dim]",
-        border_style="cyan",
-        padding=(1, 2),
-    )
-    console.print(panel)
+    console.print("[bold cyan]Eve Multi-buy / jEveAssets Stockpile Format[/bold cyan]")
+    console.print("[dim]Copy and paste into game or tool:[/dim]")
+    console.print()
+    # Print plain text without any Rich formatting for clean copy-paste
+    print(multibuy_text)
+    console.print()
+
+
+def print_markdown_export(markdown_text: str) -> None:
+    """
+    Print the markdown export text as plain text for easy copying to Discord.
+
+    Args:
+        markdown_text: Markdown format text to display
+    """
+    if not markdown_text:
+        return
+
+    console.print()
+    console.print("[bold cyan]Discord Markdown Format[/bold cyan]")
+    console.print("[dim]Copy and paste into Discord:[/dim]")
+    console.print()
+    # Print plain text without any Rich formatting for clean copy-paste
+    print(markdown_text)
+    console.print()

--- a/src/mkts_backend/cli_tools/rich_display.py
+++ b/src/mkts_backend/cli_tools/rich_display.py
@@ -160,6 +160,7 @@ def print_fit_header(
     total_fit_cost: float,
     total_fits: Optional[float] = None,
     target: Optional[int] = None,
+    width: Optional[int] = None,
 ) -> None:
     """
     Print a formatted header for fit status display.
@@ -172,6 +173,7 @@ def print_fit_header(
         total_fit_cost: Total cost of the fit
         total_fits: Total complete fits available (minimum of fits column)
         target: Target quantity from doctrine_fits
+        width: Optional width to constrain the header panel
     """
     header_text = Text()
     header_text.append("Ship: ", style="bold white")
@@ -203,6 +205,8 @@ def print_fit_header(
         title=f"[bold]{fit_name}[/bold]",
         border_style="blue",
         padding=(0, 2),
+        width=width,
+        expand=False,
     )
     console.print(panel)
 

--- a/src/mkts_backend/cli_tools/rich_display.py
+++ b/src/mkts_backend/cli_tools/rich_display.py
@@ -108,6 +108,7 @@ def create_fit_status_table(
         price = item.get("price")
         fit_price = item.get("fit_price", 0)
         is_fallback = item.get("is_fallback", False)
+        is_ship = item.get("is_ship", False)
 
         # Color coding based on availability
         if fits >= 10:
@@ -120,6 +121,9 @@ def create_fit_status_table(
         # Mark fallback data with asterisk
         source_indicator = "[yellow]*[/yellow]" if is_fallback else "[green]✓[/green]"
 
+        # Style ship row differently (bold cyan name)
+        name_display = f"[bold cyan]{type_name}[/bold cyan]" if is_ship else type_name
+
         # Calculate qty_needed if target is set
         if target is not None:
             qty_needed = max(0, int((target - fits) * fit_qty)) if fits < target else 0
@@ -128,7 +132,7 @@ def create_fit_status_table(
 
             table.add_row(
                 str(type_id),
-                type_name,
+                name_display,
                 format_quantity(market_stock),
                 str(fit_qty),
                 f"[{fits_style}]{format_fits(fits)}[/{fits_style}]",
@@ -136,17 +140,19 @@ def create_fit_status_table(
                 format_isk(price, include_suffix=False),
                 format_isk(fit_price, include_suffix=False),
                 source_indicator,
+                end_section=is_ship,  # Add divider after ship row
             )
         else:
             table.add_row(
                 str(type_id),
-                type_name,
+                name_display,
                 format_quantity(market_stock),
                 str(fit_qty),
                 f"[{fits_style}]{format_fits(fits)}[/{fits_style}]",
                 format_isk(price, include_suffix=False),
                 format_isk(fit_price, include_suffix=False),
                 source_indicator,
+                end_section=is_ship,  # Add divider after ship row
             )
 
     return table

--- a/src/mkts_backend/cli_tools/rich_display.py
+++ b/src/mkts_backend/cli_tools/rich_display.py
@@ -1,0 +1,304 @@
+"""
+Rich display utilities for CLI output.
+
+Provides formatted tables and console output for fit market status display.
+"""
+
+from typing import Dict, List, Optional
+from rich.console import Console
+from rich.table import Table
+from rich.panel import Panel
+from rich.text import Text
+from rich import box
+
+
+console = Console()
+
+
+def format_isk(value: Optional[float], include_suffix: bool = True) -> str:
+    """
+    Format an ISK value with proper abbreviation.
+
+    Args:
+        value: The ISK value to format
+        include_suffix: Whether to include " ISK" suffix
+
+    Returns:
+        Formatted string like "1.23B ISK" or "456.78M ISK"
+    """
+    if value is None:
+        return "N/A"
+
+    suffix = " ISK" if include_suffix else ""
+
+    if value >= 1_000_000_000:
+        return f"{value / 1_000_000_000:,.2f}B{suffix}"
+    elif value >= 1_000_000:
+        return f"{value / 1_000_000:,.2f}M{suffix}"
+    elif value >= 1_000:
+        return f"{value / 1_000:,.2f}K{suffix}"
+    else:
+        return f"{value:,.2f}{suffix}"
+
+
+def format_quantity(value: Optional[int]) -> str:
+    """Format a quantity with comma separators."""
+    if value is None:
+        return "0"
+    return f"{value:,}"
+
+
+def format_fits(value: Optional[float]) -> str:
+    """Format number of fits with one decimal place."""
+    if value is None or value < 0:
+        return "N/A"
+    return f"{value:,.1f}"
+
+
+def create_fit_status_table(
+    fit_name: str,
+    ship_name: str,
+    ship_type_id: Optional[int],
+    market_data: List[Dict],
+    total_fit_cost: float,
+    market_name: str = "primary",
+    target: Optional[int] = None,
+) -> Table:
+    """
+    Create a Rich table displaying fit market status.
+
+    Args:
+        fit_name: Name of the fit
+        ship_name: Name of the ship
+        ship_type_id: Type ID of the ship hull
+        market_data: List of item market data dicts
+        total_fit_cost: Total cost of the fit
+        market_name: Name of the market being queried
+        target: Optional target quantity for qty_needed calculation
+
+    Returns:
+        A Rich Table object ready for display
+    """
+    table = Table(
+        title=f"[bold cyan]{fit_name}[/bold cyan]",
+        box=box.ROUNDED,
+        show_header=True,
+        header_style="bold magenta",
+        title_justify="left",
+    )
+
+    # Define columns matching the plan specification
+    table.add_column("Type ID", style="dim", justify="right", width=10)
+    table.add_column("Item Name", style="white", min_width=30)
+    table.add_column("Stock", justify="right", width=10)
+    table.add_column("Fit Qty", justify="right", width=8)
+    table.add_column("Fits", justify="right", width=8)
+    if target is not None:
+        table.add_column("Qty Needed", justify="right", width=10)
+    table.add_column("Price", justify="right", width=14)
+    table.add_column("Fit Cost", justify="right", width=14)
+    table.add_column("Source", justify="center", width=8)
+
+    for item in market_data:
+        type_id = item.get("type_id", 0)
+        type_name = item.get("type_name", "Unknown")
+        market_stock = item.get("market_stock", 0)
+        fit_qty = item.get("fit_qty", 1)
+        fits = item.get("fits", 0)
+        price = item.get("price")
+        fit_price = item.get("fit_price", 0)
+        is_fallback = item.get("is_fallback", False)
+
+        # Color coding based on availability
+        if fits >= 10:
+            fits_style = "green"
+        elif fits >= 1:
+            fits_style = "yellow"
+        else:
+            fits_style = "red"
+
+        # Mark fallback data with asterisk
+        source_indicator = "[yellow]*[/yellow]" if is_fallback else "[green]✓[/green]"
+
+        # Calculate qty_needed if target is set
+        if target is not None:
+            qty_needed = max(0, int((target - fits) * fit_qty)) if fits < target else 0
+            qty_needed_str = format_quantity(qty_needed) if qty_needed > 0 else "-"
+            qty_needed_style = "red" if qty_needed > 0 else "dim"
+
+            table.add_row(
+                str(type_id),
+                type_name,
+                format_quantity(market_stock),
+                str(fit_qty),
+                f"[{fits_style}]{format_fits(fits)}[/{fits_style}]",
+                f"[{qty_needed_style}]{qty_needed_str}[/{qty_needed_style}]",
+                format_isk(price, include_suffix=False),
+                format_isk(fit_price, include_suffix=False),
+                source_indicator,
+            )
+        else:
+            table.add_row(
+                str(type_id),
+                type_name,
+                format_quantity(market_stock),
+                str(fit_qty),
+                f"[{fits_style}]{format_fits(fits)}[/{fits_style}]",
+                format_isk(price, include_suffix=False),
+                format_isk(fit_price, include_suffix=False),
+                source_indicator,
+            )
+
+    return table
+
+
+def print_fit_header(
+    fit_name: str,
+    ship_name: str,
+    ship_type_id: Optional[int],
+    market_name: str,
+    total_fit_cost: float,
+    total_fits: Optional[float] = None,
+    target: Optional[int] = None,
+) -> None:
+    """
+    Print a formatted header for fit status display.
+
+    Args:
+        fit_name: Name of the fit
+        ship_name: Name of the ship
+        ship_type_id: Type ID of the ship
+        market_name: Name of the market
+        total_fit_cost: Total cost of the fit
+        total_fits: Total complete fits available (minimum of fits column)
+        target: Target quantity from doctrine_fits
+    """
+    header_text = Text()
+    header_text.append("Ship: ", style="bold white")
+    header_text.append(f"{ship_name}", style="cyan")
+    if ship_type_id:
+        header_text.append(f" (ID: {ship_type_id})", style="dim")
+    header_text.append("\n")
+    header_text.append("Market: ", style="bold white")
+    header_text.append(f"{market_name}", style="green")
+    header_text.append("\n")
+    header_text.append("Total Fit Cost: ", style="bold white")
+    header_text.append(format_isk(total_fit_cost), style="bold yellow")
+
+    # Add total fits available
+    if total_fits is not None:
+        header_text.append("\n")
+        header_text.append("Fits Available: ", style="bold white")
+        fits_style = "green" if total_fits >= 10 else ("yellow" if total_fits >= 1 else "red")
+        header_text.append(f"{total_fits:.1f}", style=f"bold {fits_style}")
+
+    # Add target if known
+    if target is not None:
+        header_text.append("\n")
+        header_text.append("Target: ", style="bold white")
+        header_text.append(f"{target}", style="bold magenta")
+
+    panel = Panel(
+        header_text,
+        title=f"[bold]{fit_name}[/bold]",
+        border_style="blue",
+        padding=(0, 2),
+    )
+    console.print(panel)
+
+
+def print_fit_summary(
+    available_count: int,
+    total_count: int,
+    min_fits: float,
+    missing_items: List[str],
+) -> None:
+    """
+    Print a summary of fit availability.
+
+    Args:
+        available_count: Number of items with stock
+        total_count: Total number of items in fit
+        min_fits: Minimum number of complete fits available
+        missing_items: List of items with insufficient stock
+    """
+    console.print()
+
+    # Availability summary
+    if available_count == total_count:
+        status_style = "bold green"
+        status_msg = "All items available"
+    elif available_count > total_count * 0.8:
+        status_style = "bold yellow"
+        status_msg = "Most items available"
+    else:
+        status_style = "bold red"
+        status_msg = "Low availability"
+
+    console.print(f"[{status_style}]Status: {status_msg}[/{status_style}]")
+    console.print(f"Items: [cyan]{available_count}[/cyan]/[white]{total_count}[/white] available")
+    console.print(f"Complete fits possible: [bold yellow]{format_fits(min_fits)}[/bold yellow]")
+
+    if missing_items:
+        console.print()
+        console.print("[bold red]Items with insufficient stock:[/bold red]")
+        for item in missing_items[:5]:
+            console.print(f"  • {item}", style="red")
+        if len(missing_items) > 5:
+            console.print(f"  ... and {len(missing_items) - 5} more", style="dim red")
+
+
+def print_legend() -> None:
+    """Print a legend explaining the table columns and indicators."""
+    legend = """
+[bold]Legend:[/bold]
+  [green]✓[/green] = Data from watchlist/marketstats
+  [yellow]*[/yellow] = Fallback data (marketorders + ESI)
+  [green]Fits >= 10[/green] = Good stock
+  [yellow]Fits 1-9[/yellow] = Low stock
+  [red]Fits < 1[/red] = Insufficient stock
+"""
+    console.print(legend, style="dim")
+
+
+def print_missing_for_target(missing_items: List[Dict], target: int) -> None:
+    """
+    Print a list of items missing to reach the target quantity.
+
+    Args:
+        missing_items: List of dicts with type_name and qty_needed
+        target: Target quantity
+    """
+    if not missing_items:
+        return
+
+    console.print()
+    console.print(f"[bold red]Items below target ({target}):[/bold red]")
+    for item in missing_items:
+        if item["qty_needed"] > 0:
+            console.print(
+                f"  • {item['type_name']}: [red]{format_quantity(item['qty_needed'])}[/red] needed "
+                f"(current: {item['fits']:.1f} fits)",
+                style="white"
+            )
+
+
+def print_multibuy_export(multibuy_text: str) -> None:
+    """
+    Print the multi-buy export text in a panel for easy copying.
+
+    Args:
+        multibuy_text: Multi-buy format text to display
+    """
+    if not multibuy_text:
+        return
+
+    console.print()
+    panel = Panel(
+        multibuy_text,
+        title="[bold]Eve Multi-buy / jEveAssets Stockpile Format[/bold]",
+        subtitle="[dim]Copy and paste into game or tool[/dim]",
+        border_style="cyan",
+        padding=(1, 2),
+    )
+    console.print(panel)

--- a/src/mkts_backend/db/models.py
+++ b/src/mkts_backend/db/models.py
@@ -165,12 +165,13 @@ class DoctrineFitItems(Base):
     fit_id: Mapped[int] = mapped_column(Integer)
     ship_name: Mapped[str] = mapped_column(String)
     target: Mapped[int] = mapped_column(Integer)
+    market_flag: Mapped[str] = mapped_column(String, default="primary", nullable=True)
 
     def __repr__(self) -> str:
         return (
             f"doctrine_fits(id={self.id!r}, doctrine_name={self.doctrine_name!r}, fit_name={self.fit_name!r}, "
             f"ship_type_id={self.ship_type_id!r}, doctrine_id={self.doctrine_id!r}, fit_id={self.fit_id!r}, "
-            f"ship_name={self.ship_name!r}, target={self.target!r})"
+            f"ship_name={self.ship_name!r}, target={self.target!r}, market_flag={self.market_flag!r})"
         )
 
 

--- a/src/mkts_backend/utils/eft_parser.py
+++ b/src/mkts_backend/utils/eft_parser.py
@@ -1,0 +1,234 @@
+"""
+EFT (EVE Fitting Tool) format parser.
+
+This module provides functions for parsing EFT-formatted ship fitting files
+into structured data that can be used for market analysis and database storage.
+"""
+
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Dict, Generator, List, Optional
+
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from mkts_backend.config.logging_config import configure_logging
+from mkts_backend.config import DatabaseConfig
+
+logger = configure_logging(__name__)
+
+# Module-level SDE database connection
+_sde_db = DatabaseConfig("sde")
+
+
+@dataclass
+class FitParseResult:
+    """Result of parsing an EFT fit file."""
+    items: List[Dict]
+    ship_name: str
+    ship_type_id: Optional[int]
+    fit_name: str
+    missing_types: List[str]
+
+    @property
+    def total_items(self) -> int:
+        """Total number of unique item types in the fit."""
+        return len(self.items)
+
+    @property
+    def has_missing_types(self) -> bool:
+        """Whether any items could not be resolved to type IDs."""
+        return len(self.missing_types) > 0
+
+
+def _slot_yielder() -> Generator[str, None, None]:
+    """
+    Generate slot names in EFT order.
+
+    EFT format orders slots as: Low, Med, High, Rig, Drone, then Cargo.
+    Empty lines signal slot transitions.
+    """
+    corrected_order = ['LoSlot', 'MedSlot', 'HiSlot', 'RigSlot', 'DroneBay']
+    for slot in corrected_order:
+        yield slot
+    while True:
+        yield 'Cargo'
+
+
+def lookup_type_id(type_name: str, conn=None) -> Optional[int]:
+    """
+    Look up a type ID from the SDE by type name.
+
+    Args:
+        type_name: The item name to look up
+        conn: Optional database connection. If None, creates a new connection.
+
+    Returns:
+        The type ID if found, None otherwise
+    """
+    if conn is None:
+        engine = _sde_db.engine
+        with engine.connect() as new_conn:
+            result = new_conn.execute(
+                text("SELECT typeID FROM inv_info WHERE typeName = :type_name"),
+                {"type_name": type_name},
+            ).fetchone()
+            return result[0] if result else None
+    else:
+        result = conn.execute(
+            text("SELECT typeID FROM inv_info WHERE typeName = :type_name"),
+            {"type_name": type_name},
+        ).fetchone()
+        return result[0] if result else None
+
+
+def resolve_ship_type_id(ship_name: str, conn=None) -> Optional[int]:
+    """
+    Resolve a ship name to its type ID.
+
+    Args:
+        ship_name: The ship name to look up
+        conn: Optional database connection
+
+    Returns:
+        The ship type ID if found, None otherwise
+    """
+    return lookup_type_id(ship_name, conn)
+
+
+def parse_eft_string(eft_text: str, fit_id: int = 0, sde_engine: Engine = None) -> FitParseResult:
+    """
+    Parse an EFT-formatted string into structured items.
+
+    Args:
+        eft_text: The EFT format text to parse
+        fit_id: Optional fit ID to assign to parsed items
+        sde_engine: Optional SDE database engine. Uses default if None.
+
+    Returns:
+        FitParseResult with parsed items, ship info, and any missing types
+    """
+    if sde_engine is None:
+        sde_engine = _sde_db.engine
+
+    items: List[Dict] = []
+    missing: List[str] = []
+    slot_gen = _slot_yielder()
+    current_slot = None
+    ship_name = ""
+    ship_type_id = None
+    fit_name = ""
+    slot_counters = defaultdict(int)
+
+    with sde_engine.connect() as sde_conn:
+        for line in eft_text.strip().split('\n'):
+            line = line.strip()
+
+            # Parse header line: [Ship Name, Fit Name]
+            if line.startswith("[") and line.endswith("]"):
+                clean_name = line.strip("[]")
+                parts = clean_name.split(",")
+                ship_name = parts[0].strip()
+                fit_name = parts[1].strip() if len(parts) > 1 else "Unnamed Fit"
+                ship_type_id = resolve_ship_type_id(ship_name, sde_conn)
+                continue
+
+            # Empty line signals slot transition
+            if line == "":
+                current_slot = next(slot_gen)
+                continue
+
+            if current_slot is None:
+                current_slot = next(slot_gen)
+
+            # Parse quantity suffix (e.g., "Nanite Repair Paste x100")
+            qty_match = re.search(r"\s+x(\d+)$", line)
+            if qty_match:
+                qty = int(qty_match.group(1))
+                item_name = line[: qty_match.start()].strip()
+            else:
+                qty = 1
+                item_name = line.strip()
+
+            # Skip empty item names
+            if not item_name:
+                continue
+
+            # Generate slot name with index for fitted slots
+            if current_slot in {"LoSlot", "MedSlot", "HiSlot", "RigSlot"}:
+                suffix = slot_counters[current_slot]
+                slot_counters[current_slot] += 1
+                slot_name = f"{current_slot}{suffix}"
+            else:
+                slot_name = current_slot
+
+            # Look up type ID
+            type_id = lookup_type_id(item_name, sde_conn)
+            if type_id is None:
+                missing.append(item_name)
+                logger.warning(f"Unable to resolve type_id for '{item_name}' (fit {fit_id})")
+                continue
+
+            items.append(
+                {
+                    "flag": slot_name,
+                    "quantity": qty,
+                    "type_id": type_id,
+                    "fit_id": fit_id,
+                    "type_fk_id": type_id,
+                    "type_name": item_name,
+                }
+            )
+
+    return FitParseResult(
+        items=items,
+        ship_name=ship_name,
+        ship_type_id=ship_type_id,
+        fit_name=fit_name,
+        missing_types=missing
+    )
+
+
+def parse_eft_file(fit_file: str, fit_id: int = 0, sde_engine: Engine = None) -> FitParseResult:
+    """
+    Parse an EFT-formatted fit file into structured items.
+
+    Args:
+        fit_file: Path to the EFT format file
+        fit_id: Optional fit ID to assign to parsed items
+        sde_engine: Optional SDE database engine. Uses default if None.
+
+    Returns:
+        FitParseResult with parsed items, ship info, and any missing types
+    """
+    with open(fit_file, "r", encoding="utf-8") as f:
+        eft_text = f.read()
+
+    return parse_eft_string(eft_text, fit_id, sde_engine)
+
+
+def aggregate_fit_items(parse_result: FitParseResult) -> Dict[int, Dict]:
+    """
+    Aggregate fit items by type_id, summing quantities.
+
+    Args:
+        parse_result: The parsed fit result
+
+    Returns:
+        Dict mapping type_id to item info with aggregated quantity
+    """
+    aggregated = {}
+
+    for item in parse_result.items:
+        type_id = item["type_id"]
+        if type_id in aggregated:
+            aggregated[type_id]["quantity"] += item["quantity"]
+        else:
+            aggregated[type_id] = {
+                "type_id": type_id,
+                "type_name": item.get("type_name", ""),
+                "quantity": item["quantity"],
+            }
+
+    return aggregated

--- a/tests/test_eft_parser.py
+++ b/tests/test_eft_parser.py
@@ -1,0 +1,261 @@
+"""
+Unit tests for the EFT parser module.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+import tempfile
+import os
+
+
+class TestEFTParserString:
+    """Tests for parse_eft_string function."""
+
+    @pytest.fixture
+    def mock_sde_engine(self):
+        """Create a mock SDE database engine."""
+        mock_engine = MagicMock()
+        mock_conn = MagicMock()
+
+        # Map of type names to type IDs for testing
+        type_mapping = {
+            "Hurricane Fleet Issue": 33157,
+            "Damage Control II": 2048,
+            "Gyrostabilizer II": 519,
+            "Large Shield Extender II": 3841,
+            "720mm Howitzer Artillery II": 2961,
+            "Valkyrie II": 2446,
+            "Nanite Repair Paste": 28668,
+        }
+
+        def execute_query(query, params=None):
+            result = MagicMock()
+            if params and "type_name" in params:
+                type_name = params["type_name"]
+                if type_name in type_mapping:
+                    result.fetchone.return_value = (type_mapping[type_name],)
+                else:
+                    result.fetchone.return_value = None
+            return result
+
+        mock_conn.execute = execute_query
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_engine.connect.return_value = mock_conn
+
+        return mock_engine
+
+    def test_parse_simple_fit(self, mock_sde_engine):
+        """Test parsing a simple EFT fit string."""
+        from mkts_backend.utils.eft_parser import parse_eft_string
+
+        eft_text = """[Hurricane Fleet Issue, Test Fit]
+Damage Control II
+Gyrostabilizer II
+
+Large Shield Extender II
+
+720mm Howitzer Artillery II
+
+
+Valkyrie II x5
+
+Nanite Repair Paste x100
+"""
+        result = parse_eft_string(eft_text, fit_id=123, sde_engine=mock_sde_engine)
+
+        assert result.ship_name == "Hurricane Fleet Issue"
+        assert result.fit_name == "Test Fit"
+        assert result.ship_type_id == 33157
+        assert len(result.items) > 0
+
+    def test_parse_header_line(self, mock_sde_engine):
+        """Test that header line is correctly parsed."""
+        from mkts_backend.utils.eft_parser import parse_eft_string
+
+        eft_text = "[Hurricane Fleet Issue, WC HFI 2025]"
+        result = parse_eft_string(eft_text, sde_engine=mock_sde_engine)
+
+        assert result.ship_name == "Hurricane Fleet Issue"
+        assert result.fit_name == "WC HFI 2025"
+
+    def test_parse_quantity_suffix(self, mock_sde_engine):
+        """Test parsing items with quantity suffix (x100)."""
+        from mkts_backend.utils.eft_parser import parse_eft_string
+
+        eft_text = """[Hurricane Fleet Issue, Test]
+
+
+Valkyrie II x5
+
+Nanite Repair Paste x100
+"""
+        result = parse_eft_string(eft_text, sde_engine=mock_sde_engine)
+
+        # Find the Nanite Repair Paste entry
+        paste_items = [i for i in result.items if i["type_name"] == "Nanite Repair Paste"]
+        assert len(paste_items) == 1
+        assert paste_items[0]["quantity"] == 100
+
+    def test_missing_types_tracked(self, mock_sde_engine):
+        """Test that missing type names are tracked."""
+        from mkts_backend.utils.eft_parser import parse_eft_string
+
+        eft_text = """[Hurricane Fleet Issue, Test]
+Nonexistent Module That Does Not Exist
+"""
+        result = parse_eft_string(eft_text, sde_engine=mock_sde_engine)
+
+        assert result.has_missing_types
+        assert "Nonexistent Module That Does Not Exist" in result.missing_types
+
+    def test_empty_fit(self, mock_sde_engine):
+        """Test parsing an empty fit."""
+        from mkts_backend.utils.eft_parser import parse_eft_string
+
+        eft_text = "[Hurricane Fleet Issue, Empty Fit]"
+        result = parse_eft_string(eft_text, sde_engine=mock_sde_engine)
+
+        assert result.ship_name == "Hurricane Fleet Issue"
+        assert result.fit_name == "Empty Fit"
+        assert len(result.items) == 0
+
+    def test_slot_assignment(self, mock_sde_engine):
+        """Test that slots are correctly assigned."""
+        from mkts_backend.utils.eft_parser import parse_eft_string
+
+        eft_text = """[Hurricane Fleet Issue, Test]
+Damage Control II
+Gyrostabilizer II
+
+Large Shield Extender II
+
+720mm Howitzer Artillery II
+"""
+        result = parse_eft_string(eft_text, sde_engine=mock_sde_engine)
+
+        # Check slot assignments
+        dc2 = next((i for i in result.items if i["type_name"] == "Damage Control II"), None)
+        assert dc2 is not None
+        assert dc2["flag"].startswith("LoSlot")
+
+        lse = next((i for i in result.items if i["type_name"] == "Large Shield Extender II"), None)
+        assert lse is not None
+        assert lse["flag"].startswith("MedSlot")
+
+
+class TestEFTParserFile:
+    """Tests for parse_eft_file function."""
+
+    @pytest.fixture
+    def mock_sde_engine(self):
+        """Create a mock SDE database engine."""
+        mock_engine = MagicMock()
+        mock_conn = MagicMock()
+
+        type_mapping = {
+            "Hurricane Fleet Issue": 33157,
+            "Damage Control II": 2048,
+            "Large Shield Extender II": 3841,
+            "720mm Howitzer Artillery II": 2961,
+            "Valkyrie II": 2446,
+        }
+
+        def execute_query(query, params=None):
+            result = MagicMock()
+            if params and "type_name" in params:
+                type_name = params["type_name"]
+                if type_name in type_mapping:
+                    result.fetchone.return_value = (type_mapping[type_name],)
+                else:
+                    result.fetchone.return_value = None
+            return result
+
+        mock_conn.execute = execute_query
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_engine.connect.return_value = mock_conn
+
+        return mock_engine
+
+    def test_parse_file_not_found(self):
+        """Test that FileNotFoundError is raised for missing file."""
+        from mkts_backend.utils.eft_parser import parse_eft_file
+
+        with pytest.raises(FileNotFoundError):
+            parse_eft_file("/nonexistent/path/to/fit.txt")
+
+    def test_parse_real_fit_file(self, mock_sde_engine):
+        """Test parsing a real fit file."""
+        from mkts_backend.utils.eft_parser import parse_eft_file
+
+        # Create a temporary EFT file
+        eft_content = """[Hurricane Fleet Issue, Test Fit]
+Damage Control II
+
+Large Shield Extender II
+
+720mm Howitzer Artillery II
+
+
+Valkyrie II x5
+"""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
+            f.write(eft_content)
+            temp_path = f.name
+
+        try:
+            with patch('mkts_backend.utils.eft_parser._sde_db') as mock_db:
+                mock_db.engine = mock_sde_engine
+                result = parse_eft_file(temp_path, fit_id=123, sde_engine=mock_sde_engine)
+
+                assert result.ship_name == "Hurricane Fleet Issue"
+                assert result.fit_name == "Test Fit"
+        finally:
+            os.unlink(temp_path)
+
+
+class TestAggregateFitItems:
+    """Tests for aggregate_fit_items function."""
+
+    def test_aggregate_duplicate_items(self):
+        """Test that duplicate items are aggregated."""
+        from mkts_backend.utils.eft_parser import FitParseResult, aggregate_fit_items
+
+        # Create a parse result with duplicate items
+        result = FitParseResult(
+            items=[
+                {"type_id": 100, "type_name": "Item A", "quantity": 5},
+                {"type_id": 100, "type_name": "Item A", "quantity": 3},
+                {"type_id": 200, "type_name": "Item B", "quantity": 1},
+            ],
+            ship_name="Test Ship",
+            ship_type_id=12345,
+            fit_name="Test Fit",
+            missing_types=[],
+        )
+
+        aggregated = aggregate_fit_items(result)
+
+        assert 100 in aggregated
+        assert aggregated[100]["quantity"] == 8  # 5 + 3
+        assert 200 in aggregated
+        assert aggregated[200]["quantity"] == 1
+
+
+class TestSlotYielder:
+    """Tests for the slot yielder generator."""
+
+    def test_slot_order(self):
+        """Test that slots are yielded in correct order."""
+        from mkts_backend.utils.eft_parser import _slot_yielder
+
+        gen = _slot_yielder()
+
+        assert next(gen) == "LoSlot"
+        assert next(gen) == "MedSlot"
+        assert next(gen) == "HiSlot"
+        assert next(gen) == "RigSlot"
+        assert next(gen) == "DroneBay"
+        assert next(gen) == "Cargo"
+        assert next(gen) == "Cargo"  # Should keep returning Cargo

--- a/tests/test_fit_check.py
+++ b/tests/test_fit_check.py
@@ -1,0 +1,469 @@
+"""
+Integration tests for the fit-check CLI command.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+import sqlite3
+import tempfile
+import os
+from pathlib import Path
+
+
+class TestFitCheckMarketData:
+    """Tests for market data retrieval."""
+
+    @pytest.fixture
+    def temp_market_db(self, tmp_path):
+        """Create a temporary market database with test data."""
+        db_path = tmp_path / "wcmktprod.db"
+        conn = sqlite3.connect(str(db_path))
+
+        # Create marketstats table
+        conn.execute("""
+            CREATE TABLE marketstats (
+                type_id INTEGER PRIMARY KEY,
+                type_name TEXT,
+                price REAL,
+                min_price REAL,
+                avg_price REAL,
+                avg_volume REAL,
+                total_volume_remain INTEGER,
+                days_remaining REAL,
+                last_update TEXT,
+                group_id INTEGER,
+                group_name TEXT,
+                category_id INTEGER,
+                category_name TEXT
+            )
+        """)
+
+        # Insert test data
+        conn.execute("""
+            INSERT INTO marketstats VALUES
+            (33157, 'Hurricane Fleet Issue', 250000000, 245000000, 260000000, 50, 100, 30.5, '2025-01-01', 6, 'Battlecruiser', 6, 'Ship'),
+            (2048, 'Damage Control II', 1500000, 1400000, 1600000, 500, 5000, 45.2, '2025-01-01', 7, 'Damage Control', 7, 'Module'),
+            (519, 'Gyrostabilizer II', 2000000, 1900000, 2100000, 300, 3000, 40.0, '2025-01-01', 8, 'Gyrostabilizer', 7, 'Module'),
+            (3841, 'Large Shield Extender II', 3500000, 3400000, 3600000, 200, 2000, 35.0, '2025-01-01', 9, 'Shield Extender', 7, 'Module')
+        """)
+
+        # Create marketorders table for fallback testing
+        conn.execute("""
+            CREATE TABLE marketorders (
+                order_id INTEGER PRIMARY KEY,
+                type_id INTEGER,
+                price REAL,
+                volume_remain INTEGER,
+                is_buy_order INTEGER
+            )
+        """)
+
+        # Insert fallback order data
+        conn.execute("""
+            INSERT INTO marketorders VALUES
+            (1, 99999, 1000000, 100, 0),
+            (2, 99999, 1100000, 50, 0),
+            (3, 99999, 1200000, 75, 0)
+        """)
+
+        conn.commit()
+        conn.close()
+
+        return db_path
+
+    @pytest.fixture
+    def temp_sde_db(self, tmp_path):
+        """Create a temporary SDE database with test data."""
+        db_path = tmp_path / "sde.db"
+        conn = sqlite3.connect(str(db_path))
+
+        conn.execute("""
+            CREATE TABLE inv_info (
+                typeID INTEGER PRIMARY KEY,
+                typeName TEXT,
+                groupID INTEGER,
+                groupName TEXT,
+                categoryID INTEGER,
+                categoryName TEXT
+            )
+        """)
+
+        conn.execute("""
+            INSERT INTO inv_info VALUES
+            (33157, 'Hurricane Fleet Issue', 6, 'Battlecruiser', 6, 'Ship'),
+            (2048, 'Damage Control II', 7, 'Damage Control', 7, 'Module'),
+            (519, 'Gyrostabilizer II', 8, 'Gyrostabilizer', 7, 'Module'),
+            (3841, 'Large Shield Extender II', 9, 'Shield Extender', 7, 'Module'),
+            (99999, 'Fallback Item', 10, 'Test Group', 8, 'Test Category')
+        """)
+
+        conn.commit()
+        conn.close()
+
+        return db_path
+
+    def test_get_marketstats_data(self, temp_market_db, tmp_path):
+        """Test retrieving data from marketstats."""
+        from mkts_backend.cli_tools.fit_check import _get_marketstats_data
+
+        with patch('mkts_backend.cli_tools.fit_check.DatabaseConfig') as mock_db_config:
+            # Setup mock
+            mock_instance = MagicMock()
+            mock_db_config.return_value = mock_instance
+
+            from sqlalchemy import create_engine
+            mock_instance.engine = create_engine(f"sqlite:///{temp_market_db}")
+
+            # Test the function
+            with patch('mkts_backend.config.market_context.MarketContext') as mock_ctx:
+                mock_ctx.database_alias = "wcmkt"
+                results = _get_marketstats_data([33157, 2048], market_ctx=None)
+
+            assert 33157 in results
+            assert results[33157]["type_name"] == "Hurricane Fleet Issue"
+            assert results[33157]["price"] == 250000000
+
+    def test_get_fallback_data(self, temp_market_db, tmp_path):
+        """Test fallback data retrieval from marketorders."""
+        from mkts_backend.cli_tools.fit_check import _get_fallback_data
+
+        with patch('mkts_backend.cli_tools.fit_check.DatabaseConfig') as mock_db_config:
+            mock_instance = MagicMock()
+            mock_db_config.return_value = mock_instance
+
+            from sqlalchemy import create_engine
+            mock_instance.engine = create_engine(f"sqlite:///{temp_market_db}")
+
+            result = _get_fallback_data(99999, market_ctx=None)
+
+            assert result is not None
+            assert result["type_id"] == 99999
+            assert result["total_volume_remain"] == 225  # 100 + 50 + 75
+            assert result["is_fallback"] == True
+
+    def test_get_fallback_data_no_orders(self, temp_market_db):
+        """Test fallback returns None when no orders exist."""
+        from mkts_backend.cli_tools.fit_check import _get_fallback_data
+
+        with patch('mkts_backend.cli_tools.fit_check.DatabaseConfig') as mock_db_config:
+            mock_instance = MagicMock()
+            mock_db_config.return_value = mock_instance
+
+            from sqlalchemy import create_engine
+            mock_instance.engine = create_engine(f"sqlite:///{temp_market_db}")
+
+            result = _get_fallback_data(88888, market_ctx=None)  # Non-existent type
+
+            assert result is None
+
+
+class TestFitCheckDisplay:
+    """Tests for Rich display formatting."""
+
+    def test_format_isk_billions(self):
+        """Test ISK formatting for billions."""
+        from mkts_backend.cli_tools.rich_display import format_isk
+
+        assert format_isk(1_500_000_000) == "1.50B ISK"
+        assert format_isk(250_000_000) == "250.00M ISK"
+
+    def test_format_isk_millions(self):
+        """Test ISK formatting for millions."""
+        from mkts_backend.cli_tools.rich_display import format_isk
+
+        assert format_isk(5_000_000) == "5.00M ISK"
+        assert format_isk(1_500_000) == "1.50M ISK"
+
+    def test_format_isk_thousands(self):
+        """Test ISK formatting for thousands."""
+        from mkts_backend.cli_tools.rich_display import format_isk
+
+        assert format_isk(50_000) == "50.00K ISK"
+        assert format_isk(1_500) == "1.50K ISK"
+
+    def test_format_isk_none(self):
+        """Test ISK formatting for None value."""
+        from mkts_backend.cli_tools.rich_display import format_isk
+
+        assert format_isk(None) == "N/A"
+
+    def test_format_quantity(self):
+        """Test quantity formatting."""
+        from mkts_backend.cli_tools.rich_display import format_quantity
+
+        assert format_quantity(1000) == "1,000"
+        assert format_quantity(1000000) == "1,000,000"
+        assert format_quantity(None) == "0"
+
+    def test_format_fits(self):
+        """Test fits formatting."""
+        from mkts_backend.cli_tools.rich_display import format_fits
+
+        assert format_fits(10.5) == "10.5"
+        assert format_fits(0.5) == "0.5"
+        assert format_fits(None) == "N/A"
+
+
+class TestFitCheckCommand:
+    """Tests for the fit-check CLI command."""
+
+    @pytest.fixture
+    def temp_fit_file(self, tmp_path):
+        """Create a temporary EFT fit file."""
+        fit_content = """[Hurricane Fleet Issue, Test Fit]
+Damage Control II
+Gyrostabilizer II
+
+Large Shield Extender II
+
+"""
+        fit_path = tmp_path / "test_fit.txt"
+        fit_path.write_text(fit_content)
+        return str(fit_path)
+
+    def test_fit_check_command_file_not_found(self):
+        """Test fit-check with non-existent file."""
+        from mkts_backend.cli_tools.fit_check import fit_check_command
+
+        with patch('mkts_backend.cli_tools.fit_check.MarketContext') as mock_ctx:
+            mock_ctx.from_settings.return_value = MagicMock(
+                name="Test Market",
+                database_alias="wcmkt"
+            )
+
+            result = fit_check_command(
+                file_path="/nonexistent/path.txt",
+                market_alias="primary"
+            )
+
+            assert result == False
+
+    def test_fit_check_command_no_input(self):
+        """Test fit-check with neither file nor paste."""
+        from mkts_backend.cli_tools.fit_check import fit_check_command
+
+        result = fit_check_command(file_path=None, eft_text=None)
+        assert result == False
+
+    def test_fit_check_command_invalid_market(self, temp_fit_file):
+        """Test fit-check with invalid market alias."""
+        from mkts_backend.cli_tools.fit_check import fit_check_command
+
+        with patch('mkts_backend.cli_tools.fit_check.MarketContext') as mock_ctx:
+            mock_ctx.from_settings.side_effect = ValueError("Unknown market")
+            mock_ctx.list_available.return_value = ["primary", "deployment"]
+
+            result = fit_check_command(
+                file_path=temp_fit_file,
+                market_alias="invalid_market"
+            )
+
+            assert result == False
+
+
+class TestGetFitMarketStatus:
+    """Tests for the get_fit_market_status function."""
+
+    def test_calculates_fits_correctly(self):
+        """Test that fits are calculated correctly."""
+        from mkts_backend.cli_tools.fit_check import get_fit_market_status
+        from mkts_backend.utils.eft_parser import FitParseResult
+
+        # Create a mock parse result
+        parse_result = FitParseResult(
+            items=[
+                {"type_id": 100, "type_name": "Test Module", "quantity": 2},
+            ],
+            ship_name="Test Ship",
+            ship_type_id=200,
+            fit_name="Test Fit",
+            missing_types=[],
+        )
+
+        with patch('mkts_backend.cli_tools.fit_check._get_marketstats_data') as mock_stats:
+            with patch('mkts_backend.cli_tools.fit_check._get_target_for_fit') as mock_target:
+                mock_target.return_value = None
+                mock_stats.return_value = {
+                    100: {"type_name": "Test Module", "price": 1000000, "avg_price": 1100000, "total_volume_remain": 100},
+                    200: {"type_name": "Test Ship", "price": 50000000, "avg_price": 55000000, "total_volume_remain": 10},
+                }
+
+                result = get_fit_market_status(parse_result, market_ctx=None)
+
+                # Find the module entry
+                module_entry = next(e for e in result.market_data if e["type_id"] == 100)
+                assert module_entry["fits"] == 50.0  # 100 stock / 2 qty
+
+                # Find the ship entry
+                ship_entry = next(e for e in result.market_data if e["type_id"] == 200)
+                assert ship_entry["fits"] == 10.0  # 10 stock / 1 qty
+
+    def test_calculates_fit_price(self):
+        """Test that fit price is calculated correctly."""
+        from mkts_backend.cli_tools.fit_check import get_fit_market_status
+        from mkts_backend.utils.eft_parser import FitParseResult
+
+        parse_result = FitParseResult(
+            items=[
+                {"type_id": 100, "type_name": "Test Module", "quantity": 5},
+            ],
+            ship_name="Test Ship",
+            ship_type_id=200,
+            fit_name="Test Fit",
+            missing_types=[],
+        )
+
+        with patch('mkts_backend.cli_tools.fit_check._get_marketstats_data') as mock_stats:
+            with patch('mkts_backend.cli_tools.fit_check._get_target_for_fit') as mock_target:
+                mock_target.return_value = None
+                mock_stats.return_value = {
+                    100: {"type_name": "Test Module", "price": 1000000, "avg_price": 1100000, "total_volume_remain": 100},
+                    200: {"type_name": "Test Ship", "price": 50000000, "avg_price": 55000000, "total_volume_remain": 10},
+                }
+
+                result = get_fit_market_status(parse_result, market_ctx=None)
+
+                # Find the module entry
+                module_entry = next(e for e in result.market_data if e["type_id"] == 100)
+                assert module_entry["fit_price"] == 5000000  # 5 * 1000000
+
+
+class TestFitCheckResult:
+    """Tests for FitCheckResult dataclass and export methods."""
+
+    def test_missing_for_target_calculation(self):
+        """Test that missing_for_target calculates correctly."""
+        from mkts_backend.cli_tools.fit_check import FitCheckResult
+
+        market_data = [
+            {"type_id": 100, "type_name": "Module A", "fits": 50.0, "fit_qty": 2},
+            {"type_id": 101, "type_name": "Module B", "fits": 80.0, "fit_qty": 1},
+            {"type_id": 102, "type_name": "Module C", "fits": 120.0, "fit_qty": 3},
+        ]
+
+        result = FitCheckResult(
+            fit_name="Test Fit",
+            ship_name="Test Ship",
+            ship_type_id=12345,
+            market_data=market_data,
+            total_fit_cost=100000000,
+            min_fits=50.0,
+            target=100,
+            market_name="primary",
+        )
+
+        missing = result.missing_for_target
+        assert len(missing) == 2  # Module A and B are below target
+        # Module A: (100 - 50) * 2 = 100
+        assert any(m["type_name"] == "Module A" and m["qty_needed"] == 100 for m in missing)
+        # Module B: (100 - 80) * 1 = 20
+        assert any(m["type_name"] == "Module B" and m["qty_needed"] == 20 for m in missing)
+
+    def test_missing_for_target_no_target(self):
+        """Test that missing_for_target returns empty when no target."""
+        from mkts_backend.cli_tools.fit_check import FitCheckResult
+
+        result = FitCheckResult(
+            fit_name="Test Fit",
+            ship_name="Test Ship",
+            ship_type_id=12345,
+            market_data=[{"type_id": 100, "type_name": "Module A", "fits": 50.0, "fit_qty": 2}],
+            total_fit_cost=100000000,
+            min_fits=50.0,
+            target=None,
+            market_name="primary",
+        )
+
+        assert result.missing_for_target == []
+
+    def test_to_multibuy_format(self):
+        """Test multi-buy export format."""
+        from mkts_backend.cli_tools.fit_check import FitCheckResult
+
+        market_data = [
+            {"type_id": 100, "type_name": "Damage Control II", "fits": 50.0, "fit_qty": 1},
+            {"type_id": 101, "type_name": "Gyrostabilizer II", "fits": 80.0, "fit_qty": 3},
+            {"type_id": 102, "type_name": "Large Shield Extender II", "fits": 120.0, "fit_qty": 2},
+        ]
+
+        result = FitCheckResult(
+            fit_name="Test Fit",
+            ship_name="Test Ship",
+            ship_type_id=12345,
+            market_data=market_data,
+            total_fit_cost=100000000,
+            min_fits=50.0,
+            target=100,
+            market_name="primary",
+        )
+
+        multibuy = result.to_multibuy()
+        lines = multibuy.strip().split("\n")
+        assert len(lines) == 2
+        # Check format: item_name space qty_needed
+        assert "Damage Control II 50" in lines
+        assert "Gyrostabilizer II 60" in lines
+
+    def test_to_csv_export(self, tmp_path):
+        """Test CSV export."""
+        from mkts_backend.cli_tools.fit_check import FitCheckResult
+
+        market_data = [
+            {"type_id": 100, "type_name": "Module A", "market_stock": 100, "fit_qty": 2, "fits": 50.0, "price": 1000000, "fit_price": 2000000},
+            {"type_id": 101, "type_name": "Module B", "market_stock": 80, "fit_qty": 1, "fits": 80.0, "price": 500000, "fit_price": 500000},
+        ]
+
+        result = FitCheckResult(
+            fit_name="Test Fit",
+            ship_name="Test Ship",
+            ship_type_id=12345,
+            market_data=market_data,
+            total_fit_cost=2500000,
+            min_fits=50.0,
+            target=100,
+            market_name="primary",
+        )
+
+        csv_path = tmp_path / "test_export.csv"
+        exported_path = result.to_csv(str(csv_path))
+
+        assert Path(exported_path).exists()
+
+        import csv
+        with open(exported_path, "r") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+
+        assert len(rows) == 2
+        assert "qty_needed" in rows[0].keys()
+        assert rows[0]["type_name"] == "Module A"
+        assert int(rows[0]["qty_needed"]) == 100  # (100 - 50) * 2
+
+    def test_to_csv_export_no_target(self, tmp_path):
+        """Test CSV export without target column."""
+        from mkts_backend.cli_tools.fit_check import FitCheckResult
+
+        market_data = [
+            {"type_id": 100, "type_name": "Module A", "market_stock": 100, "fit_qty": 2, "fits": 50.0, "price": 1000000, "fit_price": 2000000},
+        ]
+
+        result = FitCheckResult(
+            fit_name="Test Fit",
+            ship_name="Test Ship",
+            ship_type_id=12345,
+            market_data=market_data,
+            total_fit_cost=2000000,
+            min_fits=50.0,
+            target=None,
+            market_name="primary",
+        )
+
+        csv_path = tmp_path / "test_export_no_target.csv"
+        exported_path = result.to_csv(str(csv_path))
+
+        import csv
+        with open(exported_path, "r") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+
+        assert "qty_needed" not in rows[0].keys()

--- a/uv.lock
+++ b/uv.lock
@@ -534,6 +534,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
 name = "matplotlib"
 version = "3.10.6"
 source = { registry = "https://pypi.org/simple" }
@@ -588,6 +600,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "millify"
 version = "0.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -613,6 +634,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "requests" },
     { name = "requests-oauthlib" },
+    { name = "rich" },
     { name = "seaborn" },
     { name = "sqlalchemy" },
     { name = "sqlalchemy-libsql" },
@@ -642,6 +664,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "requests", specifier = ">=2.32.4" },
     { name = "requests-oauthlib", specifier = ">=2.0.0" },
+    { name = "rich", specifier = ">=13.0.0" },
     { name = "seaborn", specifier = ">=0.13.2" },
     { name = "sqlalchemy", specifier = ">=2.0.43" },
     { name = "sqlalchemy-libsql", specifier = ">=0.2.0" },
@@ -999,6 +1022,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4", size = 219990, upload-time = "2025-10-09T14:16:53.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd", size = 243393, upload-time = "2025-10-09T14:16:51.245Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

  Implements the fit-check CLI tool for analyzing EFT ship fits against market availability, with rich terminal output and multiple export formats.

## Changes

### New Features
  - fit-check command - Analyzes EFT-formatted ship fits and displays market availability for each item
  - Market status table - Shows stock, fits available, prices, and quantities needed to reach target
  - Automatic target lookup - Pulls target quantities from doctrine_fits table when available
  - Multiple export formats via --output=<format>:
    - csv - Spreadsheet-compatible export (auto-named from fit)
    - multibuy - Eve Online multi-buy / jEveAssets stockpile format
    - markdown - Discord-friendly format with bold formatting
### UI Improvements
  - Header panel width matches data table width for cleaner display
  - Ship hull row styled in bold cyan with divider line separating it from modules
  - Color-coded availability (green ≥10 fits, yellow ≥1 fit, red <1 fit)
### Supporting Changes
  - EFT parser utility for parsing Eve Fitting Tool format
  - Rich display utilities for formatted console output
  - Fallback pricing from marketorders for items not on watchlist

Usage Examples
  # Basic fit check
  mkts-backend fit-check --file=fits/maelstrom.txt

  # With target override and multibuy export
  mkts-backend fit-check --file=fits/maelstrom.txt --target=300 --output=multibuy

  # Export markdown for Discord
  mkts-backend fit-check --file=fits/maelstrom.txt --target=300 --output=markdown

  Test plan

  - All 19 fit-check tests passing
  - EFT parser tests passing
  - Manual testing with real fit files
  - Verify export formats copy/paste correctly