### PR TITLE
feat: add Jita price comparison to fit-check

### DIFF
--- a/docs/flatten-repo-structure.md
+++ b/docs/flatten-repo-structure.md
@@ -1,0 +1,114 @@
+# Flattening the Repository Structure
+
+This document explains how to convert from the current `src/` layout to a flat layout.
+
+## Current Structure
+```
+mkts_backend/
+├── src/
+│   └── mkts_backend/
+│       ├── cli_tools/
+│       ├── config/
+│       ├── db/
+│       ├── processing/
+│       ├── utils/
+│       └── ...
+├── tests/
+├── pyproject.toml
+└── ...
+```
+
+## Target Structure
+```
+mkts_backend/
+├── mkts_backend/
+│   ├── cli_tools/
+│   ├── config/
+│   ├── db/
+│   ├── processing/
+│   ├── utils/
+│   └── ...
+├── tests/
+├── pyproject.toml
+└── ...
+```
+
+## Steps
+
+### 1. Move the package directory
+
+```bash
+# From the repo root
+mv src/mkts_backend ./mkts_backend_new
+rmdir src
+mv mkts_backend_new mkts_backend
+```
+
+Or in one step:
+```bash
+mv src/mkts_backend . && rmdir src
+```
+
+### 2. Update pyproject.toml
+
+Find the setuptools package configuration section and update it:
+
+**Before:**
+```toml
+[tool.setuptools.packages.find]
+where = ["src"]
+```
+
+**After:**
+```toml
+[tool.setuptools.packages.find]
+where = ["."]
+```
+
+If using `[tool.setuptools]` with explicit packages, update paths accordingly.
+
+### 3. Reinstall the package
+
+```bash
+# If using uv
+uv sync
+
+# Or with pip
+pip install -e .
+```
+
+### 4. Verify imports still work
+
+```bash
+uv run python -c "from mkts_backend.cli_tools.fit_check import fit_check_command; print('OK')"
+```
+
+### 5. Run tests
+
+```bash
+uv run pytest tests/ --ignore=tests/test_region_history.py --ignore=tests/test_utils.py
+```
+
+### 6. Update any hardcoded paths
+
+Search for any references to `src/mkts_backend` in:
+- CI/CD configs (`.github/workflows/`)
+- Documentation
+- Scripts
+
+```bash
+grep -r "src/mkts_backend" .
+```
+
+## Why Flatten?
+
+**Pros of flat layout:**
+- Simpler navigation (one less directory level)
+- Easier for small-to-medium projects
+- Works fine for CLI tools that aren't libraries
+
+**Cons (why `src/` exists):**
+- Without `src/`, you can accidentally import the local uninstalled package
+- Can mask packaging bugs (missing files in distribution)
+
+For this project (primarily a CLI tool), the flat layout is reasonable.

--- a/src/mkts_backend/utils/jita.py
+++ b/src/mkts_backend/utils/jita.py
@@ -1,3 +1,23 @@
+"""
+Jita price utilities for fetching and working with Jita market prices.
+
+Uses the Fuzzwork Market API for efficient bulk price lookups.
+"""
+
+import requests
+from typing import Dict, List, Optional
+
+from mkts_backend.config.logging_config import configure_logging
+
+logger = configure_logging(__name__)
+
+# Fuzzwork Market API endpoint for aggregated market data
+FUZZWORK_API_URL = "https://market.fuzzwork.co.uk/aggregates/"
+
+# The Forge region ID (Jita's region)
+JITA_REGION_ID = 10000002
+
+
 class JitaPrice:
     def __init__(self, type_id: int, price_data: dict):
         self.type_id = type_id
@@ -18,6 +38,108 @@ class JitaPrice:
             'sell_percentile': self.sell_percentile,
             'buy_percentile': self.buy_percentile
         }
+
+
+def fetch_jita_prices(type_ids: List[int]) -> Dict[int, Optional[float]]:
+    """
+    Fetch Jita sell prices for a list of type IDs using Fuzzwork Market API.
+
+    Uses the sell percentile (5th percentile of sell orders) as the reference price,
+    which represents a reasonable buy price in Jita.
+
+    Args:
+        type_ids: List of type IDs to fetch prices for
+
+    Returns:
+        Dict mapping type_id to sell_percentile price (or None if not found)
+    """
+    if not type_ids:
+        return {}
+
+    results = {}
+
+    # Fuzzwork API accepts comma-separated type IDs
+    type_ids_str = ",".join(str(tid) for tid in type_ids)
+
+    headers = {
+        'User-Agent': 'wcmkts_backend/2.1, orthel.toralen@gmail.com',
+        'Accept': 'application/json',
+    }
+
+    try:
+        params = {
+            'region': JITA_REGION_ID,
+            'types': type_ids_str,
+        }
+
+        response = requests.get(FUZZWORK_API_URL, headers=headers, params=params, timeout=30)
+        response.raise_for_status()
+
+        data = response.json()
+
+        for type_id_str, price_data in data.items():
+            type_id = int(type_id_str)
+            try:
+                # Use sell percentile (5th percentile) as the reference Jita price
+                sell_percentile = float(price_data['sell']['percentile'])
+                # Only use valid prices (non-zero)
+                if sell_percentile > 0:
+                    results[type_id] = sell_percentile
+                else:
+                    results[type_id] = None
+            except (KeyError, ValueError, TypeError):
+                results[type_id] = None
+
+    except requests.exceptions.RequestException as e:
+        logger.warning(f"Failed to fetch Jita prices: {e}")
+        # Return None for all type_ids on failure
+        for type_id in type_ids:
+            results[type_id] = None
+
+    # Fill in any missing type_ids with None
+    for type_id in type_ids:
+        if type_id not in results:
+            results[type_id] = None
+
+    return results
+
+
+def get_overpriced_items(
+    market_data: List[Dict],
+    threshold: float = 1.2,
+) -> List[Dict]:
+    """
+    Get items whose local market price exceeds the Jita price by a threshold.
+
+    Args:
+        market_data: List of item dicts with 'price' and 'jita_price' keys
+        threshold: Price ratio threshold (1.2 = 120% of Jita price)
+
+    Returns:
+        List of overpriced items with price comparison data
+    """
+    overpriced = []
+
+    for item in market_data:
+        local_price = item.get("price")
+        jita_price = item.get("jita_price")
+
+        if local_price and jita_price and jita_price > 0:
+            price_ratio = local_price / jita_price
+            if price_ratio > threshold:
+                overpriced.append({
+                    "type_id": item.get("type_id"),
+                    "type_name": item.get("type_name"),
+                    "local_price": local_price,
+                    "jita_price": jita_price,
+                    "price_ratio": price_ratio,
+                    "percent_above_jita": (price_ratio - 1) * 100,
+                })
+
+    # Sort by price ratio (highest first)
+    overpriced.sort(key=lambda x: x["price_ratio"], reverse=True)
+
+    return overpriced
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add Jita price columns and comparison functionality:
- Add fetch_jita_prices() using Fuzzwork Market API for bulk price lookups
- Add jita_price and jita_fit_price columns to fit-check display table
- Add jita_fit_cost to the header panel
- Add overpriced_items property to FitCheckResult (items > 120% of Jita)
- Add print_overpriced_items() to display items priced above Jita threshold
- Add get_overpriced_items() utility function for price comparison