### PR TITLE
feat: add paste mode for fit input and fix add_watchlist import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ oldenv
 cli
 db
 esi
+temp_file.txt

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ cat fit.txt | uv run fit-check --paste
 
 ### update-fit - Update Doctrine Fits
 
-Process EFT fit files and update doctrine tables. Supports interactive metadata input and multi-market targeting.
+Process EFT fit files (or pasted EFT text) and update doctrine tables. Supports interactive metadata input, paste mode, and multi-market targeting.
 
 ```bash
 # Update fit with metadata file
@@ -135,17 +135,22 @@ uv run mkts-backend update-fit --fit-file=fits/hfi.txt --meta-file=meta.json --b
 
 # Preview changes (dry run)
 uv run mkts-backend update-fit --fit-file=fits/hfi.txt --fit-id=313 --interactive --dry-run
+
+# Paste EFT text directly (opens multiline prompt)
+uv run mkts-backend fit-update add --paste --interactive
+uv run mkts-backend fit-update update --fit-id=313 --paste
 ```
 
 **Available Subcommands:**
-- `add` - Add a NEW fit from an EFT file
-- `update` - Update an existing fit's items
+- `add` - Add a NEW fit from an EFT file or pasted text
+- `update` - Update an existing fit's items from file or pasted text
 - `assign-market` - Change market assignment
 - `list-fits` - List all fits in tracking system
 - `list-doctrines` - List all available doctrines
 - `create-doctrine` - Create a new doctrine
 - `doctrine-add-fit` - Add existing fit(s) to a doctrine
 - `doctrine-remove-fit` - Remove fit(s) from a doctrine
+- `update-target` - Update the target quantity for a fit
 
 ```bash
 # Add existing fits to a doctrine (supports multiple)
@@ -153,12 +158,15 @@ uv run mkts-backend update-fit doctrine-add-fit --doctrine-id=42 --fit-ids=313,3
 
 # Remove fits from a doctrine (reverse of doctrine-add-fit)
 uv run mkts-backend update-fit doctrine-remove-fit --doctrine-id=42 --fit-id=313
+
+# Update target quantity for a fit
+uv run mkts-backend update-target --fit-id=313 --target=300
 ```
 
 **Input Modes:**
 - `--file=<path>`: Parse an EFT-formatted fit file and query live market data
 - `--fit-id=<id>`: Look up fit by ID from doctrine_fits table and display pre-calculated market data from doctrines table
-- `--paste`: Read EFT fit from stdin
+- `--paste`: Open a multiline prompt to paste EFT fit text directly (uses prompt_toolkit)
 
 **Features:**
 - Displays complete fit breakdown with market availability

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "libsql>=0.1.11",
     "python-dotenv>=1.1.1",
     "rich>=13.0.0",
+    "prompt-toolkit>=3.0.52",
 ]
 
 [build-system]

--- a/src/mkts_backend/cli_tools/__init__.py
+++ b/src/mkts_backend/cli_tools/__init__.py
@@ -3,9 +3,10 @@ CLI subpackage for mkts-backend doctrine tools.
 
 This package contains CLI commands for managing EVE Online fits and doctrines:
 - fit-check: Display market availability for EFT fits
-- fit-update: Interactive tool for managing fits and doctrines
+- fit-update: Interactive tool for managing fits and doctrines (file or paste input)
 - add_watchlist: Add items to watchlist by type IDs
 - args_parser: Parse command line arguments
+- prompter: Multiline input prompter for pasting EFT fit text
 - collect_fit_metadata_interactive: Collect fit metadata interactively
 - display_cli_help: Display general CLI help
 - display_update_fit_help: Display update fit help

--- a/src/mkts_backend/cli_tools/__init__.py
+++ b/src/mkts_backend/cli_tools/__init__.py
@@ -14,10 +14,29 @@ This package contains CLI commands for managing EVE Online fits and doctrines:
 """
 
 from mkts_backend.cli_tools.fit_check import fit_check_command
-from mkts_backend.cli_tools.fit_update import fit_update_command, collect_fit_metadata_interactive
-from mkts_backend.cli_tools.cli_help import display_cli_help, display_update_fit_help, display_update_target_help
+from mkts_backend.cli_tools.fit_update import (
+    fit_update_command,
+    collect_fit_metadata_interactive,
+    parse_fit_from_std_in,
+)
+from mkts_backend.cli_tools.cli_help import (
+    display_cli_help,
+    display_update_fit_help,
+    display_update_target_help,
+)
 from mkts_backend.cli_tools.add_watchlist import add_watchlist
 from mkts_backend.cli_tools.args_parser import parse_args
 from mkts_backend.cli_tools.cli_db_commands import check_tables
 
-__all__ = ["fit_check_command", "fit_update_command", "collect_fit_metadata_interactive", "add_watchlist", "parse_args", "display_cli_help", "display_update_fit_help", "display_update_target_help", "check_tables"]
+__all__ = [
+    "fit_check_command",
+    "fit_update_command",
+    "collect_fit_metadata_interactive",
+    "add_watchlist",
+    "parse_args",
+    "display_cli_help",
+    "display_update_fit_help",
+    "display_update_target_help",
+    "check_tables",
+    "parse_fit_from_std_in",
+]

--- a/src/mkts_backend/cli_tools/__init__.py
+++ b/src/mkts_backend/cli_tools/__init__.py
@@ -17,7 +17,6 @@ from mkts_backend.cli_tools.fit_check import fit_check_command
 from mkts_backend.cli_tools.fit_update import (
     fit_update_command,
     collect_fit_metadata_interactive,
-    parse_fit_from_std_in,
 )
 from mkts_backend.cli_tools.cli_help import (
     display_cli_help,
@@ -27,6 +26,7 @@ from mkts_backend.cli_tools.cli_help import (
 from mkts_backend.cli_tools.add_watchlist import add_watchlist
 from mkts_backend.cli_tools.args_parser import parse_args
 from mkts_backend.cli_tools.cli_db_commands import check_tables
+from mkts_backend.cli_tools.prompter import get_multiline_input
 
 __all__ = [
     "fit_check_command",
@@ -38,5 +38,5 @@ __all__ = [
     "display_update_fit_help",
     "display_update_target_help",
     "check_tables",
-    "parse_fit_from_std_in",
+    "get_multiline_input",
 ]

--- a/src/mkts_backend/cli_tools/add_watchlist.py
+++ b/src/mkts_backend/cli_tools/add_watchlist.py
@@ -1,4 +1,5 @@
 from mkts_backend.config.logging_config import configure_logging
+from mkts_backend.utils.db_utils import add_missing_items_to_watchlist
 
 logger = configure_logging(__name__)
 

--- a/src/mkts_backend/cli_tools/args_parser.py
+++ b/src/mkts_backend/cli_tools/args_parser.py
@@ -177,7 +177,7 @@ def parse_args(args: list[str]) -> dict | None:
                 fit_file = arg.split("=", 1)[1]
             elif arg.startswith("--meta-file="):
                 meta_file = arg.split("=", 1)[1]
-            elif arg.startswith("--fit-id="):
+            elif arg.startswith("--fit-id=") or arg.startswith("--fit_id"):
                 try:
                     fit_id = int(arg.split("=", 1)[1])
                 except ValueError:
@@ -243,6 +243,8 @@ def parse_args(args: list[str]) -> dict | None:
                 else:
                     metadata_dict = None  # Use metadata object directly
             else:
+                from fit_update import collect_fit_metadata_interactive
+
                 # Interactive mode - collect metadata from user
                 metadata_dict = collect_fit_metadata_interactive(
                     fit_id, fit_file)
@@ -422,7 +424,7 @@ def parse_args(args: list[str]) -> dict | None:
                 file_path = arg.split("=", 1)[1]
             elif arg.startswith("--meta-file="):
                 meta_file = arg.split("=", 1)[1]
-            elif arg.startswith("--fit-id="):
+            elif arg.startswith("--fit-id=") or arg.startswith("--fit_id="):
                 fit_ids_str = arg.split("=", 1)[1]
             elif arg.startswith("--target="):
                 # Target quantity for doctrine-add-fit

--- a/src/mkts_backend/cli_tools/args_parser.py
+++ b/src/mkts_backend/cli_tools/args_parser.py
@@ -1,20 +1,30 @@
-
 from mkts_backend.cli_tools.add_watchlist import add_watchlist
-from mkts_backend.cli_tools.cli_help import display_cli_help, display_update_fit_help, display_fit_check_help, display_fit_update_help, display_update_target_help
+from mkts_backend.cli_tools.cli_help import (
+    display_cli_help,
+    display_update_fit_help,
+    display_fit_check_help,
+    display_fit_update_help,
+    display_update_target_help,
+)
 
 from mkts_backend.config.market_context import MarketContext
 from mkts_backend.config.config import DatabaseConfig
 from mkts_backend.utils.validation import validate_all
 from mkts_backend.utils.parse_items import parse_items
 from mkts_backend.utils.parse_fits import parse_fit_metadata
-from mkts_backend.cli_tools.fit_update import fit_update_command
+from mkts_backend.cli_tools.fit_update import (
+    fit_update_command,
+    parse_fit,
+    parse_fit_from_std_in,
+)
 from mkts_backend.cli_tools.fit_check import fit_check_command
 from mkts_backend.cli_tools.cli_db_commands import check_tables
 from mkts_backend.config.logging_config import configure_logging
 
 logger = configure_logging(__name__)
 
-def parse_args(args: list[str])->dict | None:
+
+def parse_args(args: list[str]) -> dict | None:
     return_args = {}
 
     if len(args) == 0:
@@ -23,7 +33,12 @@ def parse_args(args: list[str])->dict | None:
     # Handle --help: check for subcommand-specific help first
     if "--help" in args:
         # Check if this is a subcommand help request
-        subcommands_with_help = ["fit-check", "fit-update", "update-fit", "update-target"]
+        subcommands_with_help = [
+            "fit-check",
+            "fit-update",
+            "update-fit",
+            "update-target",
+        ]
         for subcmd in subcommands_with_help:
             if subcmd in args:
                 # Let the subcommand handler show its help
@@ -38,8 +53,8 @@ def parse_args(args: list[str])->dict | None:
     for arg in args:
         if arg.startswith("--market="):
             market_choice = arg.split("=", 1)[1]
-            if market_choice == 'north' or market_choice =='North':
-                market_alias = 'deployment'
+            if market_choice == "north" or market_choice == "North":
+                market_alias = "deployment"
             else:
                 market_alias = market_choice
 
@@ -58,7 +73,9 @@ def parse_args(args: list[str])->dict | None:
         print(f"Available markets: {', '.join(available)}")
         for alias in available:
             ctx = MarketContext.from_settings(alias)
-            print(f"  {alias}: {ctx.name} (region={ctx.region_id}, db={ctx.database_alias})")
+            print(
+                f"  {alias}: {ctx.name} (region={ctx.region_id}, db={ctx.database_alias})"
+            )
         exit()
 
     if "--check_tables" in args:
@@ -77,8 +94,12 @@ def parse_args(args: list[str])->dict | None:
                 output_file = arg.split("=", 1)[1]
 
         if not input_file or not output_file:
-            print("Error: Both --input and --output parameters are required for parse-items command")
-            print("Usage: mkts-backend parse-items --input=structure_data.txt --output=market_prices.csv")
+            print(
+                "Error: Both --input and --output parameters are required for parse-items command"
+            )
+            print(
+                "Usage: mkts-backend parse-items --input=structure_data.txt --output=market_prices.csv"
+            )
             return None
 
         success = parse_items(input_file, output_file)
@@ -120,7 +141,13 @@ def parse_args(args: list[str])->dict | None:
             print("Error: --fit-id and --target are required for update-target command")
             print("Use 'mkts-backend update-target --help' for usage information.")
             return None
-        success = update_target_command(fit_id, target, market_flag=market_alias, remote=remote, db_alias=target_alias)
+        success = update_target_command(
+            fit_id,
+            target,
+            market_flag=market_alias,
+            remote=remote,
+            db_alias=target_alias,
+        )
         if success:
             print("Update target command completed successfully")
         else:
@@ -130,7 +157,6 @@ def parse_args(args: list[str])->dict | None:
     if "update-fit" in args:
         # Check for subcommand help
         if "--help" in args:
-
             display_update_fit_help()
             exit(0)
 
@@ -162,7 +188,7 @@ def parse_args(args: list[str])->dict | None:
                 elif market_val in ("primary", "deployment"):
                     target_markets = [market_val]
                 else:
-                    print(f"Error: --market must be one of: primary, deployment, both")
+                    print("Error: --market must be one of: primary, deployment, both")
                     return None
             elif arg == "--both":
                 target_markets = ["primary", "deployment"]
@@ -197,13 +223,17 @@ def parse_args(args: list[str])->dict | None:
             if meta_file:
                 metadata = parse_fit_metadata(meta_file)
                 if fit_id is not None and metadata.fit_id != fit_id:
-                    print(f"Warning: --fit-id={fit_id} overrides fit_id={metadata.fit_id} from metadata file")
+                    print(
+                        f"Warning: --fit-id={fit_id} overrides fit_id={metadata.fit_id} from metadata file"
+                    )
                     # Create new metadata dict with overridden fit_id
                     metadata_dict = {
                         "fit_id": fit_id,
                         "name": metadata.name,
                         "description": metadata.description,
-                        "doctrine_id": metadata.doctrine_ids if len(metadata.doctrine_ids) > 1 else metadata.doctrine_id,
+                        "doctrine_id": metadata.doctrine_ids
+                        if len(metadata.doctrine_ids) > 1
+                        else metadata.doctrine_id,
                         "target": metadata.target,
                     }
                 else:
@@ -221,11 +251,14 @@ def parse_args(args: list[str])->dict | None:
             # Process for each target market
             for target_market in target_markets:
                 target_alias = market_to_db[target_market]
-                print(f"\n--- Processing for {target_market} market ({target_alias}) ---")
+                print(
+                    f"\n--- Processing for {target_market} market ({target_alias}) ---"
+                )
 
                 if metadata_dict:
                     # Create FitMetadata from dict for workflow
                     from mkts_backend.utils.parse_fits import FitMetadata
+
                     metadata_obj = FitMetadata(**metadata_dict)
                 else:
                     metadata_obj = metadata
@@ -249,7 +282,9 @@ def parse_args(args: list[str])->dict | None:
                     if result["missing_items"]:
                         print(f"Missing type_ids for: {result['missing_items']}")
                 else:
-                    print(f"Fit update completed for fit_id {metadata_obj.fit_id} -> {target_alias} (remote={remote})")
+                    print(
+                        f"Fit update completed for fit_id {metadata_obj.fit_id} -> {target_alias} (remote={remote})"
+                    )
                     if update_targets:
                         print(f"  ship_targets updated")
 
@@ -295,7 +330,9 @@ def parse_args(args: list[str])->dict | None:
                     return None
 
         if not file_path and not paste_mode and fit_id is None:
-            print("Error: --file=<path>, --paste, or --fit-id=<id> is required for fit-check command")
+            print(
+                "Error: --file=<path>, --paste, or --fit-id=<id> is required for fit-check command"
+            )
             print("Use 'mkts-backend fit-check --help' for usage information.")
             return None
 
@@ -305,6 +342,7 @@ def parse_args(args: list[str])->dict | None:
             lines = []
             try:
                 import sys
+
                 for line in sys.stdin:
                     if line.strip() == "":
                         # Second blank line signals end
@@ -339,7 +377,7 @@ def parse_args(args: list[str])->dict | None:
         # Determine subcommand (first positional arg after fit-update)
         fit_update_idx = args.index("fit-update")
         subcommand = None
-        for arg in args[fit_update_idx + 1:]:
+        for arg in args[fit_update_idx + 1 :]:
             if not arg.startswith("--"):
                 subcommand = arg
                 break
@@ -354,12 +392,13 @@ def parse_args(args: list[str])->dict | None:
         meta_file = None
         fit_id = None
         db_alias = "wcmkt"  # Database alias
-        target_qty = 100    # Default target quantity for new fits
+        target_qty = 100  # Default target quantity for new fits
         interactive = "--interactive" in args
         remote = "--remote" in args
         local_only = "--local-only" in args
         dry_run = "--dry-run" in args
         skip_targets = "--skip-targets" in args
+        paste_mode = "--paste" in args
 
         fit_ids_str = None
         for arg in args:
@@ -391,6 +430,9 @@ def parse_args(args: list[str])->dict | None:
             fit_id = None
             fit_ids = None
 
+        if paste_mode:
+            eft_text = parse_fit_from_std_in()
+
         success = fit_update_command(
             subcommand=subcommand,
             fit_id=fit_id,
@@ -405,6 +447,7 @@ def parse_args(args: list[str])->dict | None:
             target_alias=db_alias,
             target=target_qty,
             skip_targets=skip_targets,
+            eft_fit=eft_text,
         )
         exit(0 if success else 1)
 
@@ -428,16 +471,22 @@ def parse_args(args: list[str])->dict | None:
         if validation_test:
             print(f"Database validated: {db.alias}")
         else:
-            print(f"Database {db.alias} is out of date. Run 'sync' to sync the database.")
+            print(
+                f"Database {db.alias} is out of date. Run 'sync' to sync the database."
+            )
         exit()
 
     if "--validate-env" in args:
         result = validate_all()
         if result["is_valid"]:
             print(result["message"])
-            print(f"Required credentials present: {', '.join(result['present_required'])}")
+            print(
+                f"Required credentials present: {', '.join(result['present_required'])}"
+            )
             if result["present_optional"]:
-                print(f"Optional credentials present: {', '.join(result['present_optional'])}")
+                print(
+                    f"Optional credentials present: {', '.join(result['present_optional'])}"
+                )
         else:
             print(result["message"])
             if result["missing_required"]:

--- a/src/mkts_backend/cli_tools/fit_update.py
+++ b/src/mkts_backend/cli_tools/fit_update.py
@@ -2,14 +2,18 @@
 Fit Update CLI commands.
 
 Interactive tools for managing fits and doctrines:
-- add: Add a new fit with optional interactive metadata prompts
-- update: Update an existing fit
+- add: Add a new fit from an EFT file or pasted text
+- update: Update an existing fit's items from file or pasted text
 - assign-market: Assign market flags to fits
 - list-fits: List all fits
 - list-doctrines: List all doctrines
 - create-doctrine: Create a new doctrine
 - doctrine-add-fit: Add existing fit(s) to a doctrine
 - doctrine-remove-fit: Remove fit(s) from a doctrine
+- update-target: Update the target quantity for a fit
+
+Supports --paste mode for pasting EFT text directly via multiline prompt
+instead of requiring a file path.
 """
 
 from typing import List, Optional
@@ -73,6 +77,7 @@ def get_available_doctrines(remote: bool = False) -> List[dict]:
 
 
 def eft_text_to_file(eft_text: str) -> str:
+    """Write EFT text to a temporary file and return the file path."""
     file_path = "temp_file.txt"
     with open(file_path, "w") as f:
         f.write(eft_text)
@@ -196,7 +201,7 @@ def interactive_add_fit(
     Interactively add a new fit with prompts for metadata.
 
     Args:
-        fit_file: Path to EFT fit file
+        fit_file: Path to EFT fit file (optional; None when using paste mode)
         remote: Use remote database
         dry_run: Preview without committing
         target_alias: Target database alias

--- a/src/mkts_backend/cli_tools/prompter.py
+++ b/src/mkts_backend/cli_tools/prompter.py
@@ -1,3 +1,11 @@
+"""
+Multiline input prompter for pasting EFT fit text into the CLI.
+
+Uses prompt_toolkit to provide a multiline input with line numbers,
+allowing users to paste EFT-formatted fit data directly instead of
+requiring a file path.
+"""
+
 from prompt_toolkit import prompt
 from prompt_toolkit.formatted_text import HTML
 
@@ -21,6 +29,15 @@ def prompt_continuation(width, line_number, wrap_count):
 
 
 def get_multiline_input() -> str:
+    """
+    Prompt the user for multiline text input (e.g., pasted EFT fit data).
+
+    Uses prompt_toolkit's multiline mode with line-numbered continuation.
+    Submit input with Meta+Enter or Esc followed by Enter.
+
+    Returns:
+        The multiline text entered by the user.
+    """
     print("Press [Meta+Enter] or [Esc] followed by [Enter] to accept input.")
     fit = prompt(
         "Multiline input: ", multiline=True, prompt_continuation=prompt_continuation

--- a/src/mkts_backend/cli_tools/prompter.py
+++ b/src/mkts_backend/cli_tools/prompter.py
@@ -1,0 +1,34 @@
+from prompt_toolkit import prompt
+from prompt_toolkit.formatted_text import HTML
+
+
+def prompt_continuation(width, line_number, wrap_count):
+    """
+    The continuation: display line numbers and '->' before soft wraps.
+
+    Notice that we can return any kind of formatted text from here.
+
+    The prompt continuation doesn't have to be the same width as the prompt
+    which is displayed before the first line, but in this example we choose to
+    align them. The `width` input that we receive here represents the width of
+    the prompt.
+    """
+    if wrap_count > 0:
+        return " " * (width - 3) + "-> "
+    else:
+        text = ("- %i - " % (line_number + 1)).rjust(width)
+        return HTML("<strong>%s</strong>") % text
+
+
+def get_multiline_input() -> str:
+    print("Press [Meta+Enter] or [Esc] followed by [Enter] to accept input.")
+    fit = prompt(
+        "Multiline input: ", multiline=True, prompt_continuation=prompt_continuation
+    )
+    print("--------------------------------------")
+    print(f"you entered: {fit}")
+    return fit
+
+
+if __name__ == "__main__":
+    pass

--- a/uv.lock
+++ b/uv.lock
@@ -631,6 +631,7 @@ dependencies = [
     { name = "millify" },
     { name = "pandas" },
     { name = "plotly" },
+    { name = "prompt-toolkit" },
     { name = "python-dotenv" },
     { name = "requests" },
     { name = "requests-oauthlib" },
@@ -661,6 +662,7 @@ requires-dist = [
     { name = "millify", specifier = ">=0.1.1" },
     { name = "pandas", specifier = ">=2.3.0" },
     { name = "plotly", specifier = ">=6.2.0" },
+    { name = "prompt-toolkit", specifier = ">=3.0.52" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "requests", specifier = ">=2.32.4" },
     { name = "requests-oauthlib", specifier = ">=2.0.0" },
@@ -896,6 +898,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
 ]
 
 [[package]]
@@ -1174,4 +1188,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/62/a7c072fbfefb2980a00f99ca994279cb9ecf310cb2e6b2a4d2a28fe192b3/wcwidth-0.5.3.tar.gz", hash = "sha256:53123b7af053c74e9fe2e92ac810301f6139e64379031f7124574212fb3b4091", size = 157587, upload-time = "2026-01-31T03:52:10.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/c1/d73f12f8cdb1891334a2ccf7389eed244d3941e74d80dd220badb937f3fb/wcwidth-0.5.3-py3-none-any.whl", hash = "sha256:d584eff31cd4753e1e5ff6c12e1edfdb324c995713f75d26c29807bb84bf649e", size = 92981, upload-time = "2026-01-31T03:52:09.14Z" },
 ]


### PR DESCRIPTION
## Summary

- **Paste mode for fit-update**: Adds `--paste` flag to `fit-update add` and `fit-update update` subcommands, allowing users to paste EFT fit text directly via a multiline prompt (powered by `prompt_toolkit`) instead of requiring a file path
- **New `prompter` module**: Introduces `cli_tools/prompter.py` with `get_multiline_input()` for line-numbered multiline text entry
- **Fix add_watchlist import bug**: The `add_missing_items_to_watchlist` function was called but never imported in `add_watchlist.py`, causing a `NameError` at runtime
- **Code formatting**: Reformats long lines and multi-argument function calls across `fit_update.py`, `parse_fits.py`, and `args_parser.py` for consistency
- **Documentation updates**: Updates docstrings, README.md, and AGENTS.md to reflect paste mode, the new `update-target` subcommand, the `prompter` module, and the `prompt_toolkit` dependency

## Test plan

- [ ] Run `mkts add_watchlist --type_id=23719` and verify it no longer raises `NameError`
- [ ] Run `mkts fit-update add --paste --interactive` and verify multiline prompt appears and accepts pasted EFT text
- [ ] Run `mkts fit-update update --fit-id=<id> --paste` and verify pasted input is written to temp file and processed
- [ ] Run `mkts fit-update list-fits` to verify existing functionality is unaffected
- [ ] Verify `--fit_id` (underscore variant) is accepted as alias for `--fit-id`
