### PR TITLE
feat: CLI Assets Tool

### DIFF
--- a/src/mkts_backend/cli_tools/args_parser.py
+++ b/src/mkts_backend/cli_tools/args_parser.py
@@ -508,6 +508,30 @@ def parse_args(args: list[str]) -> dict | None:
         success = equiv_command(args, market_alias)
         exit(0 if success else 1)
 
+    if "assets" in args:
+        from mkts_backend.cli_tools.asset_check import asset_check_command
+
+        asset_type_id = None
+        asset_type_name = None
+        for arg in args:
+            if arg.startswith("--id="):
+                try:
+                    asset_type_id = int(arg.split("=", 1)[1])
+                except ValueError:
+                    print("Error: --id must be an integer")
+                    return None
+            elif arg.startswith("--name="):
+                asset_type_name = arg.split("=", 1)[1]
+
+        if asset_type_id is None and asset_type_name is None:
+            print("Error: --id=<type_id> or --name=<type_name> is required")
+            print("Usage: mkts-backend assets --id=11379")
+            print("       mkts-backend assets --name='Damage Control'")
+            return None
+
+        success = asset_check_command(type_id=asset_type_id, type_name=asset_type_name)
+        exit(0 if success else 1)
+
     if "esi-auth" in args:
         from mkts_backend.esi.esi_auth import authorize_character, REQUIRED_SCOPES
         from mkts_backend.config.character_config import load_characters

--- a/src/mkts_backend/cli_tools/args_parser.py
+++ b/src/mkts_backend/cli_tools/args_parser.py
@@ -508,6 +508,35 @@ def parse_args(args: list[str]) -> dict | None:
         success = equiv_command(args, market_alias)
         exit(0 if success else 1)
 
+    if "esi-auth" in args:
+        from mkts_backend.esi.esi_auth import authorize_character, REQUIRED_SCOPES
+        from mkts_backend.config.character_config import load_characters
+
+        char_key = None
+        for arg in args:
+            if arg.startswith("--char="):
+                char_key = arg.split("=", 1)[1]
+
+        if char_key:
+            authorize_character(char_key, REQUIRED_SCOPES)
+        else:
+            characters = load_characters()
+            print("Available characters:")
+            for i, char in enumerate(characters, 1):
+                print(f"  {i}. {char.name} (key: {char.key})")
+            choice = input("\nEnter character key (or number): ").strip()
+            if choice.isdigit():
+                idx = int(choice) - 1
+                if 0 <= idx < len(characters):
+                    char_key = characters[idx].key
+                else:
+                    print("Invalid selection.")
+                    exit(1)
+            else:
+                char_key = choice
+            authorize_character(char_key, REQUIRED_SCOPES)
+        exit(0)
+
     if "sync" in args:
         # Determine which markets to sync
         if "--both" in args or ("--market=both" in args):

--- a/src/mkts_backend/cli_tools/asset_check.py
+++ b/src/mkts_backend/cli_tools/asset_check.py
@@ -1,0 +1,135 @@
+"""
+Asset lookup CLI command.
+
+Resolves a type by ID or partial name, fetches packaged assets for all
+configured characters via ESI, and displays a summary table.
+"""
+
+from typing import Dict, List, Optional, Tuple
+
+from sqlalchemy import text
+
+from mkts_backend.config.config import DatabaseConfig
+from mkts_backend.config.character_config import CharacterConfig, load_characters
+from mkts_backend.config.logging_config import configure_logging
+from mkts_backend.esi.character_assets import fetch_all_character_assets
+
+logger = configure_logging(__name__)
+
+
+def resolve_type(
+    type_id: Optional[int] = None,
+    type_name: Optional[str] = None,
+) -> Tuple[int, str]:
+    """
+    Resolve a type_id and type_name from either input.
+
+    If type_id is given, looks up the name.
+    If type_name is given, tries exact match then partial match.
+    For multiple partial matches, presents an interactive picker.
+
+    Returns:
+        (type_id, type_name) tuple
+
+    Raises:
+        ValueError: If the type cannot be resolved
+    """
+    sde_db = DatabaseConfig("sde")
+
+    if type_id is not None:
+        with sde_db.engine.connect() as conn:
+            result = conn.execute(
+                text("SELECT typeName FROM sdetypes WHERE typeID = :tid"),
+                {"tid": type_id},
+            ).fetchone()
+            if result:
+                return type_id, result[0]
+            raise ValueError(f"No item found with typeID={type_id}")
+
+    if type_name is not None:
+        with sde_db.engine.connect() as conn:
+            # Exact match
+            result = conn.execute(
+                text("SELECT typeID, typeName FROM sdetypes WHERE typeName = :name"),
+                {"name": type_name},
+            ).fetchone()
+            if result:
+                return result[0], result[1]
+
+            # Partial match
+            rows = conn.execute(
+                text(
+                    "SELECT typeID, typeName FROM sdetypes "
+                    "WHERE typeName LIKE :pattern ORDER BY typeName LIMIT 20"
+                ),
+                {"pattern": f"%{type_name}%"},
+            ).fetchall()
+
+            if len(rows) == 0:
+                raise ValueError(f"No item found matching '{type_name}'")
+            if len(rows) == 1:
+                return rows[0][0], rows[0][1]
+
+            # Interactive picker for multiple matches
+            print(f"\nMultiple matches for '{type_name}':")
+            for i, row in enumerate(rows, 1):
+                print(f"  {i}. {row[1]} (ID: {row[0]})")
+
+            choice = input("\nSelect number (or 'q' to cancel): ").strip()
+            if choice.lower() == "q":
+                raise ValueError("Selection cancelled")
+            try:
+                idx = int(choice) - 1
+                if 0 <= idx < len(rows):
+                    return rows[idx][0], rows[idx][1]
+                raise ValueError("Invalid selection")
+            except ValueError as e:
+                if "Invalid selection" in str(e) or "Selection cancelled" in str(e):
+                    raise
+                raise ValueError("Invalid input — enter a number")
+
+    raise ValueError("Either --id or --name is required")
+
+
+def asset_check_command(
+    type_id: Optional[int] = None,
+    type_name: Optional[str] = None,
+) -> bool:
+    """
+    Main entry point for the `assets` CLI subcommand.
+
+    Resolves the type, fetches all character assets, and displays a table.
+
+    Returns:
+        True on success, False on failure
+    """
+    from mkts_backend.cli_tools.rich_display import console, create_asset_table
+
+    try:
+        resolved_id, resolved_name = resolve_type(type_id=type_id, type_name=type_name)
+    except ValueError as e:
+        print(f"Error: {e}")
+        return False
+
+    console.print(
+        f"\nFetching assets for [bold cyan]{resolved_name}[/bold cyan] "
+        f"(ID: {resolved_id})...\n"
+    )
+
+    # Fetch assets for all characters — no type_ids filter so we get everything,
+    # then we filter to just our type
+    char_assets = fetch_all_character_assets(type_ids=[resolved_id])
+
+    # Build display data
+    rows = []
+    grand_total = 0
+    for char, assets_map in char_assets:
+        qty = assets_map.get(resolved_id, 0)
+        rows.append({"character": char.name, "short_name": char.short_name, "quantity": qty})
+        grand_total += qty
+
+    table = create_asset_table(resolved_name, resolved_id, rows, grand_total)
+    console.print(table)
+    console.print()
+
+    return True

--- a/src/mkts_backend/cli_tools/cli_help.py
+++ b/src/mkts_backend/cli_tools/cli_help.py
@@ -15,6 +15,7 @@ def display_cli_help():
   update-fit         Process an EFT fit file and update doctrine tables
   add_watchlist      Add items to watchlist by type IDs
   parse-items        Parse Eve structure data and create CSV with pricing
+  assets             Look up character assets by type ID or name
   equiv              Manage module equivalence groups (list, find, add, remove)
   esi-auth           Re-authorize ESI tokens with expanded scopes
   sync               Sync the database (supports --market/--deployment)
@@ -40,7 +41,9 @@ Examples:
   mkts-backend sync --deployment              # Sync deployment database
   mkts-backend validate --market=deployment   # Validate deployment database
   mkts-backend fit-check --file=fits/hfi.txt  # Check fit availability
-  mkts-backend equiv list                      # List all module equivalence groups
+  mkts-backend assets --name='Damage Control'   # Look up assets by partial name
+  mkts-backend assets --id=11379                # Look up assets by type ID
+  mkts-backend equiv list                       # List all module equivalence groups
   mkts-backend fit-update list-fits           # List all doctrine fits
 
 """)

--- a/src/mkts_backend/cli_tools/cli_help.py
+++ b/src/mkts_backend/cli_tools/cli_help.py
@@ -16,6 +16,7 @@ def display_cli_help():
   add_watchlist      Add items to watchlist by type IDs
   parse-items        Parse Eve structure data and create CSV with pricing
   equiv              Manage module equivalence groups (list, find, add, remove)
+  esi-auth           Re-authorize ESI tokens with expanded scopes
   sync               Sync the database (supports --market/--deployment)
   validate           Validate the database (supports --market/--deployment)
 

--- a/src/mkts_backend/cli_tools/rich_display.py
+++ b/src/mkts_backend/cli_tools/rich_display.py
@@ -601,3 +601,56 @@ def create_module_usage_table(
         table.add_row(*row_data)
 
     return table
+
+
+def create_asset_table(
+    type_name: str,
+    type_id: int,
+    rows: List[Dict],
+    grand_total: int,
+) -> Table:
+    """
+    Create a vertical Rich table showing per-character asset quantities.
+
+    Args:
+        type_name: Resolved item name
+        type_id: Item type ID
+        rows: List of dicts with character, short_name, quantity
+        grand_total: Sum of all character quantities
+
+    Returns:
+        A Rich Table object ready for display
+    """
+    table = Table(
+        title=(
+            f"[bold cyan]{type_name}[/bold cyan]"
+            f" [dim](ID: {type_id})[/dim]"
+        ),
+        box=box.ROUNDED,
+        show_header=True,
+        header_style="bold magenta",
+        title_justify="left",
+        padding=(0, 2),
+    )
+
+    table.add_column("Character", style="white", min_width=20)
+    table.add_column("Quantity", justify="right", min_width=10)
+
+    for row in rows:
+        qty = row["quantity"]
+        if qty > 0:
+            qty_str = f"[green]{format_quantity(qty)}[/green]"
+        else:
+            qty_str = "[dim]0[/dim]"
+
+        table.add_row(row["character"], qty_str)
+
+    # Total row with separator
+    total_style = "bold yellow" if grand_total > 0 else "bold red"
+    table.add_section()
+    table.add_row(
+        "[bold white]Total[/bold white]",
+        f"[{total_style}]{format_quantity(grand_total)}[/{total_style}]",
+    )
+
+    return table

--- a/src/mkts_backend/config/character_config.py
+++ b/src/mkts_backend/config/character_config.py
@@ -1,0 +1,63 @@
+"""
+Character configuration loader.
+
+Reads character definitions from settings.toml for asset lookups.
+"""
+
+import tomllib
+from dataclasses import dataclass
+from typing import List
+
+from mkts_backend.config.logging_config import configure_logging
+
+logger = configure_logging(__name__)
+
+SETTINGS_FILE = "src/mkts_backend/config/settings.toml"
+
+
+@dataclass
+class CharacterConfig:
+    key: str
+    name: str
+    char_id: int
+    token_env: str
+    short_name: str
+
+
+def load_characters(settings_file: str = SETTINGS_FILE) -> List[CharacterConfig]:
+    """
+    Load character configs from settings.toml.
+
+    Merges both [characters.*] and [chareacters.*] sections for backward
+    compatibility. Characters from [characters] take precedence on key
+    collision.
+
+    Returns:
+        List of CharacterConfig objects
+    """
+    with open(settings_file, "rb") as f:
+        settings = tomllib.load(f)
+
+    merged: dict[str, dict] = {}
+
+    # Load legacy typo section first (lower precedence)
+    for key, cfg in settings.get("chareacters", {}).items():
+        if isinstance(cfg, dict):
+            merged[key] = cfg
+
+    # Load correct section (overrides on collision)
+    for key, cfg in settings.get("characters", {}).items():
+        if isinstance(cfg, dict):
+            merged[key] = cfg
+
+    chars = []
+    for key, cfg in merged.items():
+        chars.append(CharacterConfig(
+            key=key,
+            name=cfg.get("name", key),
+            char_id=cfg["char_id"],
+            token_env=cfg.get("token_env", f"REFRESH_TOKEN_{key.upper()}"),
+            short_name=cfg.get("short_name", key[:3].capitalize()),
+        ))
+
+    return chars

--- a/src/mkts_backend/config/settings.toml
+++ b/src/mkts_backend/config/settings.toml
@@ -111,17 +111,23 @@ sheet_url2 = "https://docs.google.com/spreadsheets/d/1sLr5VaUsHKfwZV_CA1K1o2bfyw
 # CHARACTERS - For Asset Checks
 # ============================================================================
 
-[chareacters.dennis]
+[characters.dennis]
 name = "Dennis Bond"
 char_id = 2116424383
+token_env = "REFRESH_TOKEN_DENNIS"
+short_name = "Den"
 
-[chareacters.orthel]
+[characters.orthel]
 name = "Orthel Toralen"
 char_id = 2116257395
+token_env = "REFRESH_TOKEN_ORTHEL"
+short_name = "Ort"
 
 [characters.clearcomms]
 name = "Cpt Clear Comms"
 char_id = 2119110792
+token_env = "REFRESH_TOKEN_CLEARCOMMS"
+short_name = "CC"
 
 
 

--- a/src/mkts_backend/esi/character_assets.py
+++ b/src/mkts_backend/esi/character_assets.py
@@ -38,18 +38,12 @@ def fetch_character_assets(char: CharacterConfig) -> Dict[int, int]:
         Dict mapping type_id to total packaged quantity.
         Returns empty dict on auth or request failure.
     """
-    refresh_token = os.getenv(char.token_env)
-    if not refresh_token:
-        logger.warning(
-            f"No refresh token for {char.name} "
-            f"(env var {char.token_env} not set)"
-        )
-        return {}
+    refresh_token = os.getenv(char.token_env, "")
 
     try:
         token = get_token_for_character(char.key, refresh_token, ASSETS_SCOPE)
     except Exception as e:
-        logger.error(f"Token refresh failed for {char.name}: {e}")
+        logger.error(f"Token fetch failed for {char.name}: {e}")
         return {}
 
     access_token = token.get("access_token", "")

--- a/src/mkts_backend/esi/character_assets.py
+++ b/src/mkts_backend/esi/character_assets.py
@@ -1,0 +1,119 @@
+"""
+Character asset fetching via ESI.
+
+Fetches packaged (non-singleton) assets for configured characters,
+returning {type_id: quantity} maps suitable for display in needed tables.
+"""
+
+import os
+from collections import defaultdict
+from typing import Dict, List, Optional
+
+import requests
+
+from mkts_backend.config.character_config import CharacterConfig, load_characters
+from mkts_backend.config.logging_config import configure_logging
+from mkts_backend.esi.esi_auth import get_token_for_character
+
+logger = configure_logging(__name__)
+
+ESI_ASSETS_URL = (
+    "https://esi.evetech.net/latest/characters/{char_id}/assets/"
+    "?datasource=tranquility&page={page}"
+)
+ASSETS_SCOPE = "esi-assets.read_assets.v1"
+
+
+def fetch_character_assets(char: CharacterConfig) -> Dict[int, int]:
+    """
+    Fetch packaged assets for a single character via ESI.
+
+    Paginates through all pages, filters to is_singleton=False (packaged),
+    and sums quantities by type_id.
+
+    Args:
+        char: Character configuration with key, char_id, token_env
+
+    Returns:
+        Dict mapping type_id to total packaged quantity.
+        Returns empty dict on auth or request failure.
+    """
+    refresh_token = os.getenv(char.token_env)
+    if not refresh_token:
+        logger.warning(
+            f"No refresh token for {char.name} "
+            f"(env var {char.token_env} not set)"
+        )
+        return {}
+
+    try:
+        token = get_token_for_character(char.key, refresh_token, ASSETS_SCOPE)
+    except Exception as e:
+        logger.error(f"Token refresh failed for {char.name}: {e}")
+        return {}
+
+    access_token = token.get("access_token", "")
+    headers = {"Authorization": f"Bearer {access_token}"}
+
+    assets: Dict[int, int] = defaultdict(int)
+    page = 1
+    max_pages = 1
+
+    while page <= max_pages:
+        url = ESI_ASSETS_URL.format(char_id=char.char_id, page=page)
+        try:
+            resp = requests.get(url, headers=headers, timeout=30)
+        except requests.RequestException as e:
+            logger.error(f"ESI request failed for {char.name} page {page}: {e}")
+            break
+
+        if resp.status_code == 403:
+            logger.error(f"ESI 403 for {char.name} — token may lack scope")
+            break
+        if resp.status_code != 200:
+            logger.error(
+                f"ESI {resp.status_code} for {char.name} page {page}"
+            )
+            break
+
+        if page == 1:
+            max_pages = int(resp.headers.get("X-Pages", 1))
+
+        for item in resp.json():
+            if not item.get("is_singleton", False):
+                assets[item["type_id"]] += item.get("quantity", 0)
+
+        page += 1
+
+    logger.info(
+        f"Fetched {sum(assets.values())} packaged items "
+        f"({len(assets)} types) for {char.name}"
+    )
+    return dict(assets)
+
+
+def fetch_all_character_assets(
+    type_ids: Optional[List[int]] = None,
+) -> List[tuple]:
+    """
+    Fetch assets for all configured characters.
+
+    Args:
+        type_ids: If provided, only include these type_ids in results.
+
+    Returns:
+        List of (CharacterConfig, {type_id: qty}) tuples, one per character.
+        Characters that fail auth are included with empty dicts.
+    """
+    characters = load_characters()
+    results = []
+
+    for char in characters:
+        assets = fetch_character_assets(char)
+
+        if type_ids is not None:
+            assets = {tid: qty for tid, qty in assets.items() if tid in type_ids}
+
+        results.append((char, assets))
+
+    return results

--- a/src/mkts_backend/esi/character_assets.py
+++ b/src/mkts_backend/esi/character_assets.py
@@ -69,6 +69,10 @@ def fetch_character_assets(char: CharacterConfig) -> Dict[int, int]:
 
         if resp.status_code == 403:
             logger.error(f"ESI 403 for {char.name} — token may lack scope")
+            print(
+                f"\nToken for {char.name} lacks required scope. Run:\n"
+                f"  mkts-backend esi-auth --char={char.key}\n"
+            )
             break
         if resp.status_code != 200:
             logger.error(

--- a/src/mkts_backend/esi/esi_auth.py
+++ b/src/mkts_backend/esi/esi_auth.py
@@ -1,6 +1,9 @@
 import os
 import json
 import time
+import threading
+import webbrowser
+from http.server import HTTPServer, BaseHTTPRequestHandler
 from dotenv import load_dotenv
 from requests_oauthlib import OAuth2Session
 from mkts_backend.config.logging_config import configure_logging
@@ -141,6 +144,127 @@ def get_token_for_character(char_key: str, refresh_token: str, scope):
     )
     _save(token)
     return token
+
+
+REQUIRED_SCOPES = [
+    "esi-universe.read_structures.v1",
+    "esi-assets.read_assets.v1",
+    "esi-markets.structure_markets.v1",
+    "esi-assets.read_corporation_assets.v1",
+]
+
+
+SUCCESS_HTML = b"""<!DOCTYPE html>
+<html><head><title>mkts-backend</title>
+<style>
+  body { font-family: system-ui, sans-serif; display: flex; justify-content: center;
+         align-items: center; height: 100vh; margin: 0; background: #1a1a2e; color: #eee; }
+  .card { text-align: center; padding: 3em; border-radius: 12px;
+          background: #16213e; box-shadow: 0 4px 20px rgba(0,0,0,0.3); }
+  h1 { color: #4ecca3; margin-bottom: 0.5em; }
+  p { color: #aaa; }
+</style></head>
+<body><div class="card">
+  <h1>Authorization Successful!</h1>
+  <p>You can close this tab and return to the terminal.</p>
+</div></body></html>"""
+
+
+class _OAuthCallbackHandler(BaseHTTPRequestHandler):
+    """HTTP handler that captures a single OAuth redirect and serves a success page."""
+
+    redirect_url: str | None = None
+
+    def do_GET(self):
+        _OAuthCallbackHandler.redirect_url = f"http://localhost:8000{self.path}"
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html")
+        self.end_headers()
+        self.wfile.write(SUCCESS_HTML)
+
+    def log_message(self, format, *args):
+        logger.debug(f"OAuth callback: {format % args}")
+
+
+def _wait_for_callback(port: int = 8000, timeout: int = 120) -> str | None:
+    """Start a one-shot HTTP server and wait for the OAuth callback.
+
+    Returns the full redirect URL, or None on timeout.
+    """
+    _OAuthCallbackHandler.redirect_url = None
+
+    try:
+        server = HTTPServer(("localhost", port), _OAuthCallbackHandler)
+    except OSError as e:
+        logger.warning(f"Could not start callback server: {e}")
+        return None
+
+    server.timeout = timeout
+
+    thread = threading.Thread(target=server.handle_request, daemon=True)
+    thread.start()
+    thread.join(timeout=timeout)
+
+    server.server_close()
+    return _OAuthCallbackHandler.redirect_url
+
+
+def authorize_character(char_key: str, scopes: list[str] | None = None):
+    """
+    Run an interactive OAuth authorization flow for a character.
+
+    Opens the ESI authorize URL in the user's browser, runs a threaded
+    callback server on localhost:8000 to capture the redirect (with 120s
+    timeout), and falls back to manual URL pasting if the server fails.
+
+    Saves tokens to token_<char_key>.json.
+
+    Args:
+        char_key: Character key (e.g. "dennis") — used for cache filename
+        scopes: OAuth scopes to request (defaults to REQUIRED_SCOPES)
+    """
+    if not CLIENT_ID:
+        raise ValueError("CLIENT_ID environment variable is not set")
+    if not SECRET_KEY:
+        raise ValueError("SECRET_KEY environment variable is not set")
+
+    scopes = scopes or REQUIRED_SCOPES
+
+    oauth = OAuth2Session(CLIENT_ID, redirect_uri=CALLBACK_URI, scope=scopes)
+    auth_url, state = oauth.authorization_url(AUTH_URL)
+
+    print(f"\nAuthorizing character '{char_key}' with scopes:")
+    for s in scopes:
+        print(f"  - {s}")
+    print(f"\nOpening browser to authorize...")
+    print(f"If the browser doesn't open, visit:\n  {auth_url}\n")
+    webbrowser.open(auth_url)
+
+    # Try automatic callback capture via threaded server
+    print("Waiting for authorization (timeout: 120s)...")
+    redirect_url = _wait_for_callback(port=8000, timeout=120)
+
+    if not redirect_url:
+        print("\nAutomatic capture failed or timed out.")
+        redirect_url = input("Paste the full redirect URL here: ").strip()
+        if not redirect_url:
+            print("No URL provided. Aborting.")
+            return
+
+    # Exchange via authorization_response (lets OAuth2Session handle code + state)
+    token = oauth.fetch_token(
+        TOKEN_URL,
+        authorization_response=redirect_url,
+        client_secret=SECRET_KEY,
+    )
+
+    token_file = f"token_{char_key}.json"
+    with open(token_file, "w") as f:
+        json.dump(token, f)
+
+    print(f"\nToken saved to {token_file}")
+    print(f"Scopes granted: {token.get('scope', 'unknown')}")
+    print(f"Character '{char_key}' is now authorized.")
 
 
 if __name__ == "__main__":

--- a/src/mkts_backend/esi/esi_auth.py
+++ b/src/mkts_backend/esi/esi_auth.py
@@ -136,6 +136,11 @@ def get_token_for_character(char_key: str, refresh_token: str, scope):
     # Refresh using the character's refresh token
     logger.info(f"Refreshing token for character '{char_key}'")
     rt = token.get("refresh_token", refresh_token) if token else refresh_token
+    if not rt:
+        raise ValueError(
+            f"No refresh token for '{char_key}' — "
+            f"run: mkts-backend esi-auth --char={char_key}"
+        )
     token = OAuth2Session(CLIENT_ID, scope=scope).refresh_token(
         TOKEN_URL,
         refresh_token=rt,
@@ -229,6 +234,9 @@ def authorize_character(char_key: str, scopes: list[str] | None = None):
         raise ValueError("SECRET_KEY environment variable is not set")
 
     scopes = scopes or REQUIRED_SCOPES
+
+    # Allow http://localhost callback — oauthlib enforces HTTPS by default
+    os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = "1"
 
     oauth = OAuth2Session(CLIENT_ID, redirect_uri=CALLBACK_URI, scope=scopes)
     auth_url, state = oauth.authorization_url(AUTH_URL)


### PR DESCRIPTION
This PR introduces a new assets tool: 
- displays quantity of needed items belonging to configured characters when the --assets flag is used with `mkts-backend needed`
- allows command line queries of configured character assets with the --id=<type_id> or --name=<full or partial str> flags.