### PR TITLE
refactor: cli explicit command for market updates

### DIFF
--- a/.github/workflows/market-data-collection.yml
+++ b/.github/workflows/market-data-collection.yml
@@ -164,8 +164,8 @@ jobs:
           # Run with --history flag at 12:00 UTC
           HISTORY_FLAG="--history"
         fi
-        echo "Running: uv run mkts-backend --market=${{ matrix.market }} $HISTORY_FLAG"
-        uv run mkts-backend --market=${{ matrix.market }} $HISTORY_FLAG
+        echo "Running: uv run mkts-backend update-markets --market=${{ matrix.market }} $HISTORY_FLAG"
+        uv run mkts-backend update-markets --market=${{ matrix.market }} $HISTORY_FLAG
       timeout-minutes: 30
 
     - name: Save database cache

--- a/src/mkts_backend/cli.py
+++ b/src/mkts_backend/cli.py
@@ -448,17 +448,16 @@ def _run_market_pipeline(
         )
 
 
-def main(history: bool = False, market_alias: str = "primary"):
-    """
-    Main function to process market orders, history, market stats, and doctrines.
+def run_market_update(history: bool = False, market_alias: str = "both") -> bool:
+    """Run the full market-data update pipeline for one or both markets.
 
-    Args:
-        history: Whether to include historical data processing.
-        market_alias: Market alias to process (e.g., "primary", "deployment", "both").
+    Handles env validation, DB init, Jita-price fetch, and per-market pipeline.
+    Returns True on success; exits non-zero on setup failures.
     """
+    from mkts_backend.cli_tools.market_args import expand_market_alias
+
     start_time = time.perf_counter()
 
-    # Validate environment credentials before proceeding
     validation_result = validate_all()
     if not validation_result["is_valid"]:
         logger.error(validation_result["message"])
@@ -476,23 +475,8 @@ def main(history: bool = False, market_alias: str = "primary"):
     logger.debug(f"Data directory created: {os.path.abspath('data')}")
     logger.debug("=" * 80)
 
-    # Parse command line arguments
-    if len(sys.argv) > 1:
-        args = parse_args(sys.argv)
+    market_aliases = expand_market_alias(market_alias)
 
-        if args is not None:
-            history = args.get("history", False)
-            market_alias = args.get("market", "primary")
-        else:
-            return
-
-    # Determine which markets to process
-    if market_alias == "both":
-        market_aliases = ["primary", "deployment"]
-    else:
-        market_aliases = [market_alias]
-
-    # Build all market contexts up front
     all_contexts = []
     for alias in market_aliases:
         try:
@@ -504,14 +488,12 @@ def main(history: bool = False, market_alias: str = "primary"):
             logger.error(f"Available markets: {', '.join(MarketContext.list_available())}")
             sys.exit(1)
 
-    # Ensure market databases are synced before querying them
     for market_ctx in all_contexts:
         db = DatabaseConfig(market_context=market_ctx)
         if db.needs_init():
             logger.info(f"Initializing market database: {db.alias}")
             db.verify_db_exists()
 
-    # Fetch Jita prices once and write to all market databases
     jita_ok = process_jita_prices(all_contexts)
     if not jita_ok:
         logger.warning("Jita price update failed; downstream stats will lack Jita comparisons")
@@ -525,6 +507,22 @@ def main(history: bool = False, market_alias: str = "primary"):
         f"Market job complete for {label} in {time.perf_counter() - start_time:.1f}s"
     )
     logger.info("=" * 80)
+    return True
+
+
+def main():
+    """Entry point for the `mkts-backend` CLI.
+
+    Bare invocation prints help. Any subcommand is dispatched via the shared
+    command registry inside ``parse_args``.
+    """
+    from mkts_backend.cli_tools.cli_help import display_cli_help
+
+    if len(sys.argv) <= 1:
+        display_cli_help()
+        return
+
+    parse_args(sys.argv)
 
 
 if __name__ == "__main__":

--- a/src/mkts_backend/cli_tools/args_parser.py
+++ b/src/mkts_backend/cli_tools/args_parser.py
@@ -119,15 +119,7 @@ def parse_args(args: list[str]) -> dict | None:
             print(f"\033[93mDid you mean?\033[0m {hint}")
             exit(1)
 
-    # ── Flags that don't exit ───────────────────────────────────
-    if p.has_flag("history", "include-history"):
-        return_args["history"] = True
-    else:
-        return_args["history"] = False
-
-    # If we have a market specified but no other command, run the main workflow
-    if return_args.get("market"):
-        return return_args
-
+    # No subcommand matched; a lone market flag is no longer a shortcut
+    # for the update pipeline — use ``mkts-backend update-markets`` instead.
     display_cli_help()
     exit()

--- a/src/mkts_backend/cli_tools/args_parser.py
+++ b/src/mkts_backend/cli_tools/args_parser.py
@@ -1,5 +1,5 @@
 from mkts_backend.cli_tools.cli_help import display_cli_help
-from mkts_backend.cli_tools.market_args import parse_market_args
+from mkts_backend.cli_tools.market_args import resolve_market_alias
 from mkts_backend.cli_tools.arg_utils import ParsedArgs, suggest_command, check_bare_args
 from mkts_backend.cli_tools.command_registry import get_registry
 
@@ -45,7 +45,8 @@ def parse_args(args: list[str]) -> dict | None:
             display_cli_help()
             exit()
 
-    market_alias = parse_market_args(args)
+    user_market = resolve_market_alias(args)
+    market_alias = user_market or "primary"
     return_args["market"] = market_alias
 
     if p.has_flag("list-markets"):
@@ -102,7 +103,8 @@ def parse_args(args: list[str]) -> dict | None:
                 )
                 print(f"\033[93mDid you mean?\033[0m mkts-backend {arg} {corrected}")
                 exit(1)
-            success = entry.handler(sub_args, market_alias)
+            effective_market = user_market or entry.default_market
+            success = entry.handler(sub_args, effective_market)
             exit(0 if success else 1)
 
     # ── Unknown positional? Suggest closest command ─────────────
@@ -119,7 +121,8 @@ def parse_args(args: list[str]) -> dict | None:
             print(f"\033[93mDid you mean?\033[0m {hint}")
             exit(1)
 
-    # No subcommand matched; a lone market flag is no longer a shortcut
-    # for the update pipeline — use ``mkts-backend update-markets`` instead.
+    # A lone market flag is not a shortcut for any subcommand.
+    print("Error: no subcommand given.")
+    print("\033[93mDid you mean?\033[0m mkts-backend update-markets")
     display_cli_help()
-    exit()
+    exit(2)

--- a/src/mkts_backend/cli_tools/cli_help.py
+++ b/src/mkts_backend/cli_tools/cli_help.py
@@ -17,6 +17,7 @@ def _build_command_list() -> str:
         name = entry.name
         aliases = f" ({', '.join(entry.aliases)})" if entry.aliases else ""
         lines.append(f"  {name:<20s}{entry.description}{aliases}")
+    lines.sort()
     return "\n".join(lines)
 
 
@@ -24,13 +25,15 @@ def display_cli_help():
     console.print("\nUsage: mkts-backend [command] [options]\n")
     console.print(f"Commands:\n{_build_command_list()}")
     console.print("""
-Global Options (apply to main workflow and most commands):
-  --market=<alias>   Select market (primary, deployment, both). Default: primary
+Global Options (accepted by most commands):
+  --market=<alias>   Select market (primary, deployment, both).
+                     update-markets and sync default to both; other commands
+                     default to primary unless noted.
   --primary          Shorthand for --market=primary
   --deployment       Shorthand for --market=deployment
-  --both             Shorthand for --market=both (process both markets in sequence)
+  --both             Shorthand for --market=both
   --env=<env>        Override app.environment temporarily (production, development)
-  --history          Include history processing (main workflow)
+  --history          Include history processing (update-markets only)
   --check_tables     Check the tables in the database (supports --market)
   --validate-env     Validate environment credentials and exit
   --list-markets     List available market configurations
@@ -39,14 +42,12 @@ Global Options (apply to main workflow and most commands):
 Use 'mkts-backend <command> --help' for more information about a command.
 
 Examples:
-  mkts-backend --history                      # Run main workflow with history
-  mkts-backend --history --deployment         # Run for deployment market
-  mkts-backend --both --history               # Run both markets with history
-  mkts-backend --market=both                  # Run both markets (no history)
-  mkts-backend --env=development              # Run against testing database
-  mkts-backend sync --both                    # Sync both databases
-  mkts-backend sync --deployment              # Sync deployment database
-  mkts-backend validate --market=deployment   # Validate deployment database
+  mkts-backend update-markets                 # Run full pipeline for both markets
+  mkts-backend update-markets --history       # With history processing
+  mkts-backend update-markets --primary       # Primary market only
+  mkts-backend sync                           # Sync both databases
+  mkts-backend sync --deployment              # Sync deployment only
+  mkts-backend validate --market=both         # Validate both databases
   mkts-backend fit-check --file=fits/hfi.txt  # Check fit availability
   mkts-backend assets --name='Damage Control'   # Look up assets by partial name
   mkts-backend assets --id=11379                # Look up assets by type ID

--- a/src/mkts_backend/cli_tools/command_registry.py
+++ b/src/mkts_backend/cli_tools/command_registry.py
@@ -29,6 +29,7 @@ class CommandEntry:
     handler: HandlerFn
     aliases: list[str] = field(default_factory=list)
     description: str = ""
+    default_market: str = "primary"
 
     @property
     def all_names(self) -> set[str]:
@@ -49,12 +50,14 @@ class CommandRegistry:
         *,
         aliases: list[str] | None = None,
         description: str = "",
+        default_market: str = "primary",
     ) -> None:
         entry = CommandEntry(
             name=name,
             handler=handler,
             aliases=aliases or [],
             description=description,
+            default_market=default_market,
         )
         self._commands.append(entry)
         for n in entry.all_names:
@@ -464,25 +467,14 @@ def _register_all(reg: CommandRegistry) -> None:
 
     # ── sync ────────────────────────────────────────────────────
     def _handle_sync(args: list[str], market_alias: str) -> bool:
-        import sys
         from mkts_backend.config.market_context import MarketContext
         from mkts_backend.config.config import DatabaseConfig
         from mkts_backend.config.logging_config import configure_logging
-        from mkts_backend.cli_tools.market_args import (
-            resolve_market_alias,
-            expand_market_alias,
-        )
+        from mkts_backend.cli_tools.market_args import expand_market_alias
 
         logger = configure_logging(__name__)
 
-        # Sync defaults to both markets when the user gave no market flag.
-        # Re-resolve from full argv so flags before OR after the subcommand
-        # are both honored; ``market_alias`` alone can't distinguish silent
-        # vs. explicit ``--primary``.
-        effective = resolve_market_alias(sys.argv[1:], default="both")
-        sync_markets = expand_market_alias(effective)
-
-        for mkt in sync_markets:
+        for mkt in expand_market_alias(market_alias):
             market_ctx = MarketContext.from_settings(mkt)
             db = DatabaseConfig(market_context=market_ctx)
             print(f"Syncing database for market: {market_ctx.name} ({market_ctx.alias})")
@@ -492,7 +484,12 @@ def _register_all(reg: CommandRegistry) -> None:
 
         return True
 
-    reg.register("sync", _handle_sync, description="Sync the database (both markets by default)")
+    reg.register(
+        "sync",
+        _handle_sync,
+        description="Sync the database (both markets by default)",
+        default_market="both",
+    )
 
     # ── validate ────────────────────────────────────────────────
     def _handle_validate(args: list[str], market_alias: str) -> bool:
@@ -517,22 +514,19 @@ def _register_all(reg: CommandRegistry) -> None:
 
     # ── update-markets ──────────────────────────────────────────
     def _handle_update_markets(args: list[str], market_alias: str) -> bool:
-        import sys
         from mkts_backend.cli_tools.arg_utils import ParsedArgs
-        from mkts_backend.cli_tools.market_args import resolve_market_alias
         from mkts_backend.cli import run_market_update
 
-        # Default to both markets unless the user explicitly picked one.
-        effective = resolve_market_alias(sys.argv[1:], default="both")
         p = ParsedArgs(args)
         history = p.has_flag("history", "include-history")
-        return run_market_update(history=history, market_alias=effective)
+        return run_market_update(history=history, market_alias=market_alias)
 
     reg.register(
         "update-markets",
         _handle_update_markets,
         aliases=["update"],
         description="Run full market-data update pipeline (both markets by default)",
+        default_market="both",
     )
 
     # ── parse-items ─────────────────────────────────────────────

--- a/src/mkts_backend/cli_tools/command_registry.py
+++ b/src/mkts_backend/cli_tools/command_registry.py
@@ -514,11 +514,13 @@ def _register_all(reg: CommandRegistry) -> None:
 
     # ── update-markets ──────────────────────────────────────────
     def _handle_update_markets(args: list[str], market_alias: str) -> bool:
+        import sys
         from mkts_backend.cli_tools.arg_utils import ParsedArgs
         from mkts_backend.cli import run_market_update
 
-        p = ParsedArgs(args)
-        history = p.has_flag("history", "include-history")
+        # Honor --history regardless of flag position; market is already
+        # resolved from full argv by the dispatcher, so do the same here.
+        history = ParsedArgs(sys.argv[1:]).has_flag("history", "include-history")
         return run_market_update(history=history, market_alias=market_alias)
 
     reg.register(

--- a/src/mkts_backend/cli_tools/command_registry.py
+++ b/src/mkts_backend/cli_tools/command_registry.py
@@ -281,10 +281,8 @@ def _register_all(reg: CommandRegistry) -> None:
             print("Use 'update-fit --help' for usage information.")
             return False
 
-        if market_alias == "both":
-            target_markets = ["primary", "deployment"]
-        else:
-            target_markets = [market_alias]
+        from mkts_backend.cli_tools.market_args import expand_market_alias
+        target_markets = expand_market_alias(market_alias)
 
         remote = p.has_flag("remote")
         clear_existing = not p.has_flag("no-clear")
@@ -466,16 +464,23 @@ def _register_all(reg: CommandRegistry) -> None:
 
     # ── sync ────────────────────────────────────────────────────
     def _handle_sync(args: list[str], market_alias: str) -> bool:
+        import sys
         from mkts_backend.config.market_context import MarketContext
         from mkts_backend.config.config import DatabaseConfig
         from mkts_backend.config.logging_config import configure_logging
+        from mkts_backend.cli_tools.market_args import (
+            resolve_market_alias,
+            expand_market_alias,
+        )
 
         logger = configure_logging(__name__)
 
-        if market_alias == "both":
-            sync_markets = ["primary", "deployment"]
-        else:
-            sync_markets = [market_alias]
+        # Sync defaults to both markets when the user gave no market flag.
+        # Re-resolve from full argv so flags before OR after the subcommand
+        # are both honored; ``market_alias`` alone can't distinguish silent
+        # vs. explicit ``--primary``.
+        effective = resolve_market_alias(sys.argv[1:], default="both")
+        sync_markets = expand_market_alias(effective)
 
         for mkt in sync_markets:
             market_ctx = MarketContext.from_settings(mkt)
@@ -487,24 +492,48 @@ def _register_all(reg: CommandRegistry) -> None:
 
         return True
 
-    reg.register("sync", _handle_sync, description="Sync the database")
+    reg.register("sync", _handle_sync, description="Sync the database (both markets by default)")
 
     # ── validate ────────────────────────────────────────────────
     def _handle_validate(args: list[str], market_alias: str) -> bool:
         from mkts_backend.config.market_context import MarketContext
         from mkts_backend.config.config import DatabaseConfig
+        from mkts_backend.cli_tools.market_args import expand_market_alias
 
-        market_ctx = MarketContext.from_settings(market_alias)
-        db = DatabaseConfig(market_context=market_ctx)
-        print(f"Validating database for market: {market_ctx.name} ({market_ctx.alias})")
-        valid = db.validate_sync()
-        if valid:
-            print(f"Database validated: {db.alias}")
-        else:
-            print(f"Database {db.alias} is out of date. Run 'sync' to sync the database.")
-        return valid
+        all_valid = True
+        for mkt in expand_market_alias(market_alias):
+            market_ctx = MarketContext.from_settings(mkt)
+            db = DatabaseConfig(market_context=market_ctx)
+            print(f"Validating database for market: {market_ctx.name} ({market_ctx.alias})")
+            valid = db.validate_sync()
+            if valid:
+                print(f"Database validated: {db.alias}")
+            else:
+                print(f"Database {db.alias} is out of date. Run 'sync' to sync the database.")
+                all_valid = False
+        return all_valid
 
     reg.register("validate", _handle_validate, description="Validate the database sync status")
+
+    # ── update-markets ──────────────────────────────────────────
+    def _handle_update_markets(args: list[str], market_alias: str) -> bool:
+        import sys
+        from mkts_backend.cli_tools.arg_utils import ParsedArgs
+        from mkts_backend.cli_tools.market_args import resolve_market_alias
+        from mkts_backend.cli import run_market_update
+
+        # Default to both markets unless the user explicitly picked one.
+        effective = resolve_market_alias(sys.argv[1:], default="both")
+        p = ParsedArgs(args)
+        history = p.has_flag("history", "include-history")
+        return run_market_update(history=history, market_alias=effective)
+
+    reg.register(
+        "update-markets",
+        _handle_update_markets,
+        aliases=["update"],
+        description="Run full market-data update pipeline (both markets by default)",
+    )
 
     # ── parse-items ─────────────────────────────────────────────
     def _handle_parse_items(args: list[str], market_alias: str) -> bool:

--- a/src/mkts_backend/cli_tools/market_args.py
+++ b/src/mkts_backend/cli_tools/market_args.py
@@ -13,6 +13,28 @@ MARKET_SYNONYMS: dict[str, str] = {
 
 VALID_MARKET_ALIASES: set[str] = {"primary", "deployment", "both"}
 
+# Sentinel returned by resolve_market_alias when the user gave no market flag.
+_UNSPECIFIED = "__unspecified__"
+
+
+def expand_market_alias(alias: str) -> list[str]:
+    """Expand a market alias into the list of concrete markets to act on.
+
+    ``"both"`` → ``["primary", "deployment"]``; anything else → ``[alias]``.
+    """
+    if alias == "both":
+        return ["primary", "deployment"]
+    return [alias]
+
+
+def resolve_market_alias(args: list[str], default: str) -> str:
+    """Like ``parse_market_args`` but returns ``default`` only when the user
+    gave no market flag at all. Lets callers distinguish "unspecified" from
+    an explicit ``--primary``.
+    """
+    resolved = parse_market_args(args, default=_UNSPECIFIED)
+    return default if resolved == _UNSPECIFIED else resolved
+
 
 def parse_market_args(args: list[str], default: str = "primary") -> str:
     """Scan args for market flags and return a normalized market alias.

--- a/src/mkts_backend/cli_tools/market_args.py
+++ b/src/mkts_backend/cli_tools/market_args.py
@@ -13,7 +13,6 @@ MARKET_SYNONYMS: dict[str, str] = {
 
 VALID_MARKET_ALIASES: set[str] = {"primary", "deployment", "both"}
 
-# Sentinel returned by resolve_market_alias when the user gave no market flag.
 _UNSPECIFIED = "__unspecified__"
 
 
@@ -27,13 +26,14 @@ def expand_market_alias(alias: str) -> list[str]:
     return [alias]
 
 
-def resolve_market_alias(args: list[str], default: str) -> str:
-    """Like ``parse_market_args`` but returns ``default`` only when the user
-    gave no market flag at all. Lets callers distinguish "unspecified" from
-    an explicit ``--primary``.
+def resolve_market_alias(args: list[str]) -> str | None:
+    """Return the explicit market alias if the user specified one, else ``None``.
+
+    Distinguishes "user gave no flag" from "user explicitly picked --primary",
+    which the subcommand-default logic in ``parse_args`` needs.
     """
     resolved = parse_market_args(args, default=_UNSPECIFIED)
-    return default if resolved == _UNSPECIFIED else resolved
+    return None if resolved == _UNSPECIFIED else resolved
 
 
 def parse_market_args(args: list[str], default: str = "primary") -> str:

--- a/tests/test_cli_market_flag.py
+++ b/tests/test_cli_market_flag.py
@@ -153,8 +153,10 @@ class TestUpdateMarketsDispatch:
     def test_update_markets_with_history(self, mock_run):
         from mkts_backend.cli_tools.args_parser import parse_args
 
-        with pytest.raises(SystemExit):
-            parse_args(["update-markets", "--market=deployment", "--history"])
+        argv = ["mkts-backend", "update-markets", "--market=deployment", "--history"]
+        with patch("sys.argv", argv):
+            with pytest.raises(SystemExit):
+                parse_args(["update-markets", "--market=deployment", "--history"])
         _, kwargs = mock_run.call_args
         assert kwargs["market_alias"] == "deployment"
         assert kwargs["history"] is True

--- a/tests/test_cli_market_flag.py
+++ b/tests/test_cli_market_flag.py
@@ -1,200 +1,160 @@
 """
 Tests for CLI --market flag parsing and routing.
+
+After the ``update-markets`` refactor, ``parse_args`` no longer returns a dict
+for bare flag invocations — it exits. Market-flag parsing is therefore tested
+at the ``parse_market_args`` / ``resolve_market_alias`` level, with routing
+tested via subcommand dispatch.
 """
 import pytest
 from unittest.mock import patch, MagicMock
 
 
-class TestCliMarketFlagParsing:
-    """Tests for CLI argument parsing of --market flag."""
+class TestParseMarketArgs:
+    """Low-level market flag parsing."""
 
-    def test_parse_market_flag_primary(self):
-        """Test parsing --market=primary."""
-        from mkts_backend.cli import parse_args
+    def test_market_flag_primary(self):
+        from mkts_backend.cli_tools.market_args import parse_market_args
 
-        args = parse_args(["--market=primary"])
+        assert parse_market_args(["--market=primary"]) == "primary"
 
-        assert args["market"] == "primary"
+    def test_market_flag_deployment(self):
+        from mkts_backend.cli_tools.market_args import parse_market_args
 
-    def test_parse_market_flag_deployment(self):
-        """Test parsing --market=deployment."""
-        from mkts_backend.cli import parse_args
+        assert parse_market_args(["--market=deployment"]) == "deployment"
 
-        args = parse_args(["--market=deployment"])
+    def test_deployment_shorthand(self):
+        from mkts_backend.cli_tools.market_args import parse_market_args
 
-        assert args["market"] == "deployment"
+        assert parse_market_args(["--deployment"]) == "deployment"
 
-    def test_parse_deployment_shorthand(self):
-        """Test parsing --deployment shorthand."""
-        from mkts_backend.cli import parse_args
+    def test_primary_shorthand(self):
+        from mkts_backend.cli_tools.market_args import parse_market_args
 
-        args = parse_args(["--deployment"])
+        assert parse_market_args(["--primary"]) == "primary"
 
-        assert args["market"] == "deployment"
+    def test_both_shorthand(self):
+        from mkts_backend.cli_tools.market_args import parse_market_args
 
-    def test_parse_primary_shorthand(self):
-        """Test parsing --primary shorthand."""
-        from mkts_backend.cli import parse_args
+        assert parse_market_args(["--both"]) == "both"
 
-        args = parse_args(["--primary"])
+    def test_default_when_unspecified(self):
+        from mkts_backend.cli_tools.market_args import parse_market_args
 
-        assert args["market"] == "primary"
+        assert parse_market_args([]) == "primary"
 
-    def test_parse_market_flag_default(self):
-        """Test default market when --market not specified."""
-        from mkts_backend.cli import parse_args
+    def test_invalid_market_exits(self):
+        from mkts_backend.cli_tools.market_args import parse_market_args
 
-        # parse_args returns None for empty args (no special flags)
-        # Use --history flag which sets return_args without exiting
-        args = parse_args(["--history"])
+        with pytest.raises(SystemExit):
+            parse_market_args(["--market=invalid_market"])
 
-        assert args["market"] == "primary"
 
-    def test_parse_market_flag_with_history(self):
-        """Test parsing --market with --history flag."""
-        from mkts_backend.cli import parse_args
+class TestResolveMarketAlias:
+    """Optional-returning resolver used by the dispatcher."""
 
-        args = parse_args(["--market=deployment", "--history"])
+    def test_returns_none_when_unspecified(self):
+        from mkts_backend.cli_tools.market_args import resolve_market_alias
 
-        assert args["market"] == "deployment"
-        assert args["history"] is True
+        assert resolve_market_alias([]) is None
+        assert resolve_market_alias(["--history"]) is None
 
-    def test_parse_list_markets_flag(self):
-        """Test parsing --list-markets flag exits after printing."""
-        from mkts_backend.cli import parse_args
+    def test_returns_alias_when_specified(self):
+        from mkts_backend.cli_tools.market_args import resolve_market_alias
 
-        # --list-markets prints markets and exits, so we expect SystemExit
+        assert resolve_market_alias(["--primary"]) == "primary"
+        assert resolve_market_alias(["--market=deployment"]) == "deployment"
+        assert resolve_market_alias(["--both"]) == "both"
+
+
+class TestCliListMarketsCommand:
+    """--list-markets exits after printing."""
+
+    def test_list_markets_flag_exits(self):
+        from mkts_backend.cli_tools.args_parser import parse_args
+
         with pytest.raises(SystemExit):
             parse_args(["--list-markets"])
 
+    def test_list_markets_returns_available_markets(self):
+        from mkts_backend.config.market_context import MarketContext
 
-class TestCliMarketContextCreation:
-    """Tests for CLI creating correct MarketContext based on --market flag."""
+        markets = MarketContext.get_available_markets()
+        assert "primary" in markets
+        assert "deployment" in markets
 
-    def test_cli_creates_primary_context_by_default(self):
-        """Test CLI creates primary MarketContext by default."""
-        from mkts_backend.cli import parse_args
+    def test_list_markets_includes_market_details(self):
+        from mkts_backend.config.market_context import MarketContext
 
-        # With a flag that returns args (--history doesn't exit), check default market
-        args = parse_args(["--history"])
-
-        # Default market should be primary
-        assert args["market"] == "primary"
-
-    @patch("mkts_backend.cli.MarketContext")
-    def test_cli_creates_deployment_context_when_specified(self, mock_context_class):
-        """Test CLI creates deployment MarketContext when --market=deployment."""
-        mock_context = MagicMock()
-        mock_context.name = "B-9C24 Keepstar"
-        mock_context_class.from_settings.return_value = mock_context
-
-        from mkts_backend.cli import parse_args
-
-        args = parse_args(["--market=deployment"])
-
-        assert args["market"] == "deployment"
-
-
-class TestCliMarketContextPassthrough:
-    """Tests for CLI passing MarketContext to processing functions."""
-
-    @patch("mkts_backend.cli.process_market_orders")
-    @patch("mkts_backend.cli.process_market_stats")
-    @patch("mkts_backend.cli.process_doctrine_stats")
-    @patch("mkts_backend.cli.validate_all")
-    @patch("mkts_backend.cli.init_databases")
-    def test_market_context_passed_to_process_functions(
-        self,
-        mock_init_db,
-        mock_validate,
-        mock_doctrine_stats,
-        mock_market_stats,
-        mock_market_orders,
-    ):
-        """Test that MarketContext is passed through to processing functions."""
-        mock_validate.return_value = True
-        mock_init_db.return_value = None
-
-        # This test verifies the structure - actual execution would need more mocking
-
-    def test_process_market_orders_accepts_market_ctx(self):
-        """Test process_market_orders function signature accepts market_ctx."""
-        from mkts_backend.cli import process_market_orders
-        import inspect
-
-        sig = inspect.signature(process_market_orders)
-        params = list(sig.parameters.keys())
-
-        assert "market_ctx" in params
-
-    def test_process_history_accepts_market_ctx(self):
-        """Test process_history function signature accepts market_ctx."""
-        from mkts_backend.cli import process_history
-        import inspect
-
-        sig = inspect.signature(process_history)
-        params = list(sig.parameters.keys())
-
-        assert "market_ctx" in params
-
-    def test_process_market_stats_accepts_market_ctx(self):
-        """Test process_market_stats function signature accepts market_ctx."""
-        from mkts_backend.cli import process_market_stats
-        import inspect
-
-        sig = inspect.signature(process_market_stats)
-        params = list(sig.parameters.keys())
-
-        assert "market_ctx" in params
-
-    def test_process_doctrine_stats_accepts_market_ctx(self):
-        """Test process_doctrine_stats function signature accepts market_ctx."""
-        from mkts_backend.cli import process_doctrine_stats
-        import inspect
-
-        sig = inspect.signature(process_doctrine_stats)
-        params = list(sig.parameters.keys())
-
-        assert "market_ctx" in params
+        for alias in MarketContext.get_available_markets():
+            ctx = MarketContext.from_settings(alias)
+            assert ctx.name is not None
+            assert ctx.region_id is not None
+            assert ctx.database_alias is not None
 
 
 class TestCliInvalidMarketHandling:
-    """Tests for CLI handling of invalid market values."""
+    """Invalid market values fail at parse time."""
 
     def test_invalid_market_in_args_exits(self):
-        """Test that invalid market value exits with error at parse time."""
-        from mkts_backend.cli import parse_args
+        from mkts_backend.cli_tools.args_parser import parse_args
 
         with pytest.raises(SystemExit):
             parse_args(["--market=invalid_market"])
 
     def test_market_context_creation_fails_for_invalid_market(self):
-        """Test that MarketContext.from_settings fails for invalid market."""
         from mkts_backend.config.market_context import MarketContext
 
         with pytest.raises(ValueError, match="Unknown market"):
             MarketContext.from_settings("invalid_market")
 
 
-class TestCliListMarketsCommand:
-    """Tests for --list-markets CLI command."""
+class TestCliMarketContextPassthrough:
+    """Processing functions still accept market_ctx."""
 
-    def test_list_markets_returns_available_markets(self):
-        """Test that list_markets shows available market configurations."""
-        from mkts_backend.config.market_context import MarketContext
+    def test_process_market_orders_accepts_market_ctx(self):
+        from mkts_backend.cli import process_market_orders
+        import inspect
 
-        markets = MarketContext.get_available_markets()
+        assert "market_ctx" in inspect.signature(process_market_orders).parameters
 
-        assert "primary" in markets
-        assert "deployment" in markets
+    def test_process_history_accepts_market_ctx(self):
+        from mkts_backend.cli import process_history
+        import inspect
 
-    def test_list_markets_includes_market_details(self):
-        """Test that each market has required details."""
-        from mkts_backend.config.market_context import MarketContext
+        assert "market_ctx" in inspect.signature(process_history).parameters
 
-        for alias in MarketContext.get_available_markets():
-            ctx = MarketContext.from_settings(alias)
+    def test_process_market_stats_accepts_market_ctx(self):
+        from mkts_backend.cli import process_market_stats
+        import inspect
 
-            assert ctx.name is not None
-            assert ctx.region_id is not None
-            assert ctx.database_alias is not None
+        assert "market_ctx" in inspect.signature(process_market_stats).parameters
+
+    def test_process_doctrine_stats_accepts_market_ctx(self):
+        from mkts_backend.cli import process_doctrine_stats
+        import inspect
+
+        assert "market_ctx" in inspect.signature(process_doctrine_stats).parameters
+
+
+class TestUpdateMarketsDispatch:
+    """--market flag routes through update-markets subcommand."""
+
+    @patch("mkts_backend.cli.run_market_update", return_value=True)
+    def test_market_deployment_routes_to_run_market_update(self, mock_run):
+        from mkts_backend.cli_tools.args_parser import parse_args
+
+        with pytest.raises(SystemExit):
+            parse_args(["update-markets", "--market=deployment"])
+        _, kwargs = mock_run.call_args
+        assert kwargs["market_alias"] == "deployment"
+
+    @patch("mkts_backend.cli.run_market_update", return_value=True)
+    def test_update_markets_with_history(self, mock_run):
+        from mkts_backend.cli_tools.args_parser import parse_args
+
+        with pytest.raises(SystemExit):
+            parse_args(["update-markets", "--market=deployment", "--history"])
+        _, kwargs = mock_run.call_args
+        assert kwargs["market_alias"] == "deployment"
+        assert kwargs["history"] is True

--- a/tests/test_cli_routing.py
+++ b/tests/test_cli_routing.py
@@ -68,19 +68,52 @@ class TestArgsParserRouting:
         with pytest.raises(SystemExit):
             parse_args(["--help"])
 
-    def test_history_flag_returned(self):
+    def test_bare_flag_only_exits_nonzero(self):
+        """Flag-only invocation with no subcommand must fail (no silent success)."""
         from mkts_backend.cli_tools.args_parser import parse_args
 
-        result = parse_args(["--history"])
-        assert result is not None
-        assert result["history"] is True
+        with pytest.raises(SystemExit) as exc_info:
+            parse_args(["--history"])
+        assert exc_info.value.code == 2
 
-    def test_no_history_flag(self):
+    def test_bare_market_flag_exits_nonzero(self):
+        """A lone --primary is not a shortcut; must not silently succeed."""
         from mkts_backend.cli_tools.args_parser import parse_args
 
-        result = parse_args(["--primary"])
-        assert result is not None
-        assert result["history"] is False
+        with pytest.raises(SystemExit) as exc_info:
+            parse_args(["--primary"])
+        assert exc_info.value.code == 2
+
+    @patch("mkts_backend.cli.run_market_update", return_value=True)
+    def test_update_markets_routes_history_flag(self, mock_run):
+        """update-markets --history forwards history=True to run_market_update."""
+        from mkts_backend.cli_tools.args_parser import parse_args
+
+        with pytest.raises(SystemExit) as exc_info:
+            parse_args(["update-markets", "--history"])
+        assert exc_info.value.code == 0
+        _, kwargs = mock_run.call_args
+        assert kwargs["history"] is True
+
+    @patch("mkts_backend.cli.run_market_update", return_value=True)
+    def test_update_markets_defaults_to_both(self, mock_run):
+        """update-markets with no --market flag dispatches market_alias='both'."""
+        from mkts_backend.cli_tools.args_parser import parse_args
+
+        with pytest.raises(SystemExit):
+            parse_args(["update-markets"])
+        _, kwargs = mock_run.call_args
+        assert kwargs["market_alias"] == "both"
+
+    @patch("mkts_backend.cli.run_market_update", return_value=True)
+    def test_update_markets_honors_explicit_primary(self, mock_run):
+        """Explicit --primary overrides the subcommand's 'both' default."""
+        from mkts_backend.cli_tools.args_parser import parse_args
+
+        with pytest.raises(SystemExit):
+            parse_args(["update-markets", "--primary"])
+        _, kwargs = mock_run.call_args
+        assert kwargs["market_alias"] == "primary"
 
     @patch(
         "mkts_backend.cli_tools.asset_check.asset_check_command", return_value=True

--- a/tests/test_cli_routing.py
+++ b/tests/test_cli_routing.py
@@ -89,9 +89,10 @@ class TestArgsParserRouting:
         """update-markets --history forwards history=True to run_market_update."""
         from mkts_backend.cli_tools.args_parser import parse_args
 
-        with pytest.raises(SystemExit) as exc_info:
-            parse_args(["update-markets", "--history"])
-        assert exc_info.value.code == 0
+        with patch("sys.argv", ["mkts-backend", "update-markets", "--history"]):
+            with pytest.raises(SystemExit) as exc_info:
+                parse_args(["update-markets", "--history"])
+            assert exc_info.value.code == 0
         _, kwargs = mock_run.call_args
         assert kwargs["history"] is True
 
@@ -104,6 +105,17 @@ class TestArgsParserRouting:
             parse_args(["update-markets"])
         _, kwargs = mock_run.call_args
         assert kwargs["market_alias"] == "both"
+
+    @patch("mkts_backend.cli.run_market_update", return_value=True)
+    def test_update_markets_history_before_subcommand(self, mock_run):
+        """--history before the subcommand must still be honored (position-agnostic)."""
+        from mkts_backend.cli_tools.args_parser import parse_args
+
+        with patch("sys.argv", ["mkts-backend", "--history", "update-markets"]):
+            with pytest.raises(SystemExit):
+                parse_args(["--history", "update-markets"])
+        _, kwargs = mock_run.call_args
+        assert kwargs["history"] is True
 
     @patch("mkts_backend.cli.run_market_update", return_value=True)
     def test_update_markets_honors_explicit_primary(self, mock_run):


### PR DESCRIPTION
This pr refactors the cli functionality. bare mkts-backend no longer triggers market update, adds update-market command for consistency with other functions. default update path (no flag) now updates both markets, or a specific market with the --market= flag.