### PR TITLE
refactor: fix silent downcasting typing footguns

### DIFF
--- a/src/mkts_backend/cli.py
+++ b/src/mkts_backend/cli.py
@@ -161,6 +161,10 @@ def process_market_stats(market_ctx: Optional[MarketContext] = None):
         else:
             logger.error("Failed to calculate market stats")
             return False
+    except (TypeError, ValueError):
+        # Dtype-contract breach or non-coercible numeric — fail loudly rather
+        # than upserting corrupted data. See data_processing.calculate_market_stats.
+        raise
     except Exception as e:
         logger.error(f"Failed to calculate market stats: {e}")
         return False

--- a/src/mkts_backend/processing/data_processing.py
+++ b/src/mkts_backend/processing/data_processing.py
@@ -42,7 +42,7 @@ def calculate_5_percentile_price(market_ctx: Optional["MarketContext"] = None) -
     logger.info(f"5 percentile price queried: {df.shape[0]} items")
     engine.dispose()
     df = df.groupby("type_id")["price"].quantile(0.05).reset_index()
-    df.price = df.price.apply(lambda x: round(x, 2))
+    df["price"] = df["price"].round(2)
     df.columns = ["type_id", "5_perc_price"]
     return df
 
@@ -106,16 +106,36 @@ def calculate_market_stats(market_ctx: Optional["MarketContext"] = None) -> pd.D
 
     df["last_update"] = pd.Timestamp.now(tz="UTC")
 
-    # Round numeric columns
-    df["days_remaining"] = df["days_remaining"].apply(lambda x: round(x, 1))
-    df["avg_price"] = df["avg_price"].apply(lambda x: round(x, 2) if pd.notnull(x) and x > 0 else 0)
-    df["avg_volume"] = df["avg_volume"].apply(lambda x: round(x, 1) if pd.notnull(x) and x > 0 else 0)
-    df["total_volume_remain"] = df["total_volume_remain"].fillna(0).astype(int)
-    df["days_remaining"] = df["days_remaining"].fillna(0)
+    # Round numeric columns with explicit dtype preservation.
+    # `.where(cond, 0.0)` substitutes the typed zero for NaN and non-positive
+    # values, avoiding the mixed int/float returns that used to produce
+    # object-dtype columns under apply lambdas.
+    df["days_remaining"] = df["days_remaining"].fillna(0).round(1).astype("float64")
+    df["avg_price"] = df["avg_price"].where(df["avg_price"] > 0, 0.0).round(2).astype("float64")
+    df["avg_volume"] = df["avg_volume"].where(df["avg_volume"] > 0, 0.0).round(1).astype("float64")
+    df["total_volume_remain"] = df["total_volume_remain"].fillna(0).astype("int64")
 
     # Ensure we have all required database columns
     db_cols = MarketStats.__table__.columns.keys()
     df = df[db_cols]
+
+    # Dtype contract: numeric columns that feed frontend fit-cost calculations
+    # must stay numeric. Fail loudly here rather than silently upserting an
+    # object-dtype column into the Float-typed marketstats table.
+    expected_dtypes = {
+        "min_price":           "float64",
+        "avg_price":           "float64",
+        "price":               "float64",
+        "avg_volume":          "float64",
+        "days_remaining":      "float64",
+        "total_volume_remain": "int64",
+    }
+    for col, expected in expected_dtypes.items():
+        if col in df.columns and str(df[col].dtype) != expected:
+            raise TypeError(
+                f"calculate_market_stats: column '{col}' has dtype "
+                f"{df[col].dtype}, expected {expected}"
+            )
 
     logger.info(f"Market stats calculated: {df.shape[0]} items")
     return df
@@ -201,8 +221,21 @@ def fill_nulls_from_history(stats: pd.DataFrame, market_ctx: Optional["MarketCon
     finally:
         session.close()
         engine.dispose()
-    if stats.isnull().sum().sum() > 0:
-        stats = stats.fillna(0)
+    # History fallback didn't cover every NaN (type_id has neither orders nor
+    # history). Fill per-column with the typed zero so numeric dtypes are
+    # preserved end-to-end — no silent object-dtype contamination of the
+    # price columns that feed frontend fit-cost calculations.
+    numeric_fills: dict[str, tuple[str, float | int]] = {
+        "min_price":           ("float64", 0.0),
+        "avg_price":           ("float64", 0.0),
+        "price":               ("float64", 0.0),
+        "avg_volume":          ("float64", 0.0),
+        "total_volume_remain": ("int64",   0),
+        "days_remaining":      ("float64", 0.0),
+    }
+    for col, (dtype, zero) in numeric_fills.items():
+        if col in stats.columns:
+            stats[col] = pd.to_numeric(stats[col], errors="raise").fillna(zero).astype(dtype)
 
     if stats.isnull().sum().sum() == 0:
         logger.info("No nulls found after filling")

--- a/src/mkts_backend/processing/data_processing.py
+++ b/src/mkts_backend/processing/data_processing.py
@@ -221,10 +221,9 @@ def fill_nulls_from_history(stats: pd.DataFrame, market_ctx: Optional["MarketCon
     finally:
         session.close()
         engine.dispose()
-    # History fallback didn't cover every NaN (type_id has neither orders nor
-    # history). Fill per-column with the typed zero so numeric dtypes are
-    # preserved end-to-end — no silent object-dtype contamination of the
-    # price columns that feed frontend fit-cost calculations.
+    # Per-column typed fill — preserves numeric dtypes end-to-end so price
+    # columns never drift to object dtype (would silently corrupt frontend
+    # fit-cost arithmetic).
     numeric_fills: dict[str, tuple[str, float | int]] = {
         "min_price":           ("float64", 0.0),
         "avg_price":           ("float64", 0.0),
@@ -237,10 +236,14 @@ def fill_nulls_from_history(stats: pd.DataFrame, market_ctx: Optional["MarketCon
         if col in stats.columns:
             stats[col] = pd.to_numeric(stats[col], errors="raise").fillna(zero).astype(dtype)
 
-    if stats.isnull().sum().sum() == 0:
-        logger.info("No nulls found after filling")
-    else:
-        logger.error(f"stats has nulls after filling: {stats.isnull().sum().sum()}")
+    residual = stats.isnull().sum()
+    residual = residual[residual > 0]
+    if len(residual) > 0:
+        raise ValueError(
+            f"fill_nulls_from_history: residual nulls in columns not covered by "
+            f"typed fill: {residual.to_dict()}"
+        )
+    logger.info("No nulls found after filling")
     return stats
 
 def calculate_doctrine_stats(market_ctx: Optional["MarketContext"] = None) -> pd.DataFrame:

--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -69,6 +69,14 @@ class TestCalculate5PercentilePrice:
         row34 = result[result.type_id == 34]
         assert row34.iloc[0]["5_perc_price"] >= 5.0
 
+    def test_output_dtype_is_float64(self, in_memory_market_db):
+        """Vectorized .round(2) must preserve float64 dtype (no apply-lambda drift)."""
+        mock_db = _MockDB(in_memory_market_db)
+        with patch("mkts_backend.processing.data_processing._get_db", return_value=mock_db):
+            from mkts_backend.processing.data_processing import calculate_5_percentile_price
+            result = calculate_5_percentile_price()
+        assert str(result["5_perc_price"].dtype) == "float64"
+
 
 # ===== fill_nulls_from_history ==============================================
 
@@ -116,7 +124,7 @@ class TestFillNullsFromHistory:
         assert result.iloc[0]["avg_volume"] == pytest.approx(1900.0, abs=1.0)
 
     def test_no_history_fills_zero(self, in_memory_market_db):
-        """When no history exists for a type_id, nulls should become 0."""
+        """When no history exists for a type_id, nulls should become typed zeros."""
         mock_db = _MockDB(in_memory_market_db)
 
         stats = pd.DataFrame({
@@ -133,10 +141,50 @@ class TestFillNullsFromHistory:
             from mkts_backend.processing.data_processing import fill_nulls_from_history
             result = fill_nulls_from_history(stats)
 
-        # No history → final fillna(0) should set everything to 0
-        assert result.iloc[0]["avg_price"] == 0
-        assert result.iloc[0]["price"] == 0
-        assert result.iloc[0]["avg_volume"] == 0
+        # No history → typed-zero fallback sets numeric columns to 0.0/0 with
+        # stable numeric dtypes (not object, not Python int).
+        assert result.iloc[0]["avg_price"] == 0.0
+        assert result.iloc[0]["price"] == 0.0
+        assert result.iloc[0]["avg_volume"] == 0.0
+        for col in ("min_price", "avg_price", "price", "avg_volume", "days_remaining"):
+            assert str(result[col].dtype) == "float64", f"{col} dtype={result[col].dtype}"
+        assert str(result["total_volume_remain"].dtype) == "int64"
+
+    def test_non_coercible_value_raises(self, in_memory_market_db):
+        """Non-numeric string in a numeric column must raise, not silently coerce."""
+        mock_db = _MockDB(in_memory_market_db)
+        stats = pd.DataFrame({
+            "type_id": [99999],  # unknown type — no history path
+            "avg_price": ["not-a-number"],
+            "min_price": [np.nan],
+            "price": [np.nan],
+            "avg_volume": [np.nan],
+            "days_remaining": [0.0],
+            "total_volume_remain": [0],
+        })
+        with patch("mkts_backend.processing.data_processing._get_db", return_value=mock_db):
+            from mkts_backend.processing.data_processing import fill_nulls_from_history
+            with pytest.raises((ValueError, TypeError)):
+                fill_nulls_from_history(stats)
+
+    def test_residual_null_outside_numeric_fills_raises(self, in_memory_market_db):
+        """A NaN in a column not covered by the typed-fill dict must raise,
+        not silently pass through with an error log."""
+        mock_db = _MockDB(in_memory_market_db)
+        stats = pd.DataFrame({
+            "type_id": [99999],
+            "avg_price": [0.0],
+            "min_price": [0.0],
+            "price": [0.0],
+            "avg_volume": [0.0],
+            "days_remaining": [0.0],
+            "total_volume_remain": [0],
+            "type_name": [np.nan],  # not in numeric_fills — must be flagged
+        })
+        with patch("mkts_backend.processing.data_processing._get_db", return_value=mock_db):
+            from mkts_backend.processing.data_processing import fill_nulls_from_history
+            with pytest.raises(ValueError, match="residual nulls"):
+                fill_nulls_from_history(stats)
 
 
 # ===== calculate_doctrine_stats =============================================
@@ -256,6 +304,65 @@ class TestCalculateMarketStats:
                 f"{col} dtype={result[col].dtype}"
             )
         assert str(result["total_volume_remain"].dtype) == "int64"
+
+    def test_dtype_contract_raises_on_object_column(self, in_memory_market_db):
+        """If a numeric column slips through as object dtype, the contract must fire.
+
+        Guards the TypeError branch — without this, a regression that
+        reintroduces apply-lambda drift would be caught by runtime only.
+        """
+        mock_db = _MockDB(in_memory_market_db)
+
+        def fake_fill(stats, market_ctx=None):
+            # Mimic production typed-fill for every numeric column, then
+            # sabotage min_price to object dtype to exercise the contract.
+            for col, (dtype, zero) in (
+                ("avg_price", ("float64", 0.0)),
+                ("price", ("float64", 0.0)),
+                ("avg_volume", ("float64", 0.0)),
+                ("days_remaining", ("float64", 0.0)),
+                ("total_volume_remain", ("int64", 0)),
+            ):
+                if col in stats.columns:
+                    stats[col] = pd.to_numeric(stats[col], errors="raise").fillna(zero).astype(dtype)
+            stats["min_price"] = stats["min_price"].fillna(0.0).astype(object)
+            return stats
+
+        with patch("mkts_backend.processing.data_processing._get_db", return_value=mock_db), \
+             patch("mkts_backend.processing.data_processing.fill_nulls_from_history",
+                   side_effect=fake_fill):
+            import mkts_backend.processing.data_processing as dp
+            dp._wcmkt_db = None
+            with pytest.raises(TypeError, match=r"min_price.*expected float64"):
+                dp.calculate_market_stats()
+
+    @pytest.mark.parametrize("injected", [np.nan, 0.0, -1.0])
+    def test_where_boundary_collapses_to_zero(self, in_memory_market_db, injected):
+        """NaN, exactly-0, and negative avg_price/avg_volume all collapse to 0.0 float64
+        via .where(col > 0, 0.0) — distinct inputs, same typed output.
+        """
+        mock_db = _MockDB(in_memory_market_db)
+
+        def fake_fill(stats, market_ctx=None):
+            stats["avg_price"] = injected
+            stats["avg_volume"] = injected
+            for col, zero in (("min_price", 0.0), ("price", 0.0),
+                              ("days_remaining", 0.0), ("total_volume_remain", 0)):
+                stats[col] = stats[col].fillna(zero)
+            stats["total_volume_remain"] = stats["total_volume_remain"].astype("int64")
+            return stats
+
+        with patch("mkts_backend.processing.data_processing._get_db", return_value=mock_db), \
+             patch("mkts_backend.processing.data_processing.fill_nulls_from_history",
+                   side_effect=fake_fill):
+            import mkts_backend.processing.data_processing as dp
+            dp._wcmkt_db = None
+            result = dp.calculate_market_stats()
+
+        assert (result["avg_price"] == 0.0).all()
+        assert (result["avg_volume"] == 0.0).all()
+        assert str(result["avg_price"].dtype) == "float64"
+        assert str(result["avg_volume"].dtype) == "float64"
 
     def test_soldout_no_history_price_is_numeric_zero(self, in_memory_market_db):
         """Mexallon (type_id=36) has no orders AND no history.

--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -238,3 +238,38 @@ class TestCalculateMarketStats:
         assert len(row36) == 1
         # days_remaining defaults to 30 when avg_volume is 0/NULL (per SQL CASE)
         assert row36.iloc[0]["days_remaining"] == 30.0
+
+    def test_output_dtypes_contract(self, in_memory_market_db):
+        """Numeric columns must have stable numeric dtypes, not object.
+
+        Guards against silent dtype drift that would corrupt frontend fit-cost
+        calculations (price arithmetic on object-dtype columns is a latent bug).
+        """
+        mock_db = _MockDB(in_memory_market_db)
+        with patch("mkts_backend.processing.data_processing._get_db", return_value=mock_db):
+            import mkts_backend.processing.data_processing as dp
+            dp._wcmkt_db = None
+            result = dp.calculate_market_stats()
+
+        for col in ("min_price", "avg_price", "price", "avg_volume", "days_remaining"):
+            assert str(result[col].dtype) == "float64", (
+                f"{col} dtype={result[col].dtype}"
+            )
+        assert str(result["total_volume_remain"].dtype) == "int64"
+
+    def test_soldout_no_history_price_is_numeric_zero(self, in_memory_market_db):
+        """Mexallon (type_id=36) has no orders AND no history.
+
+        Its price must be float 0.0 (the typed fallback), not Python int 0 or
+        an object-dtype string — otherwise frontend fit-cost breaks.
+        """
+        mock_db = _MockDB(in_memory_market_db)
+        with patch("mkts_backend.processing.data_processing._get_db", return_value=mock_db):
+            import mkts_backend.processing.data_processing as dp
+            dp._wcmkt_db = None
+            result = dp.calculate_market_stats()
+
+        row = result[result.type_id == 36].iloc[0]
+        assert row["price"] == 0.0
+        assert isinstance(row["price"], float)
+        assert str(result["price"].dtype) == "float64"


### PR DESCRIPTION
Eliminate typing footguns that will fail on future Pandas updates when current fillna behavior is eventually depracated. Ensure types are firmly anchored in market stats alternative calculations (such as when inferring price for a sold out item from history. A type regression now breaks the backend pipeline loudly instead of landing stringified prices in marketstats for the frontend to trip over.