### PR TITLE
fix: assign/unassign-market discover fits across all configured markets

### DIFF
--- a/src/mkts_backend/cli_tools/fit_update.py
+++ b/src/mkts_backend/cli_tools/fit_update.py
@@ -28,6 +28,7 @@ from sqlalchemy.exc import OperationalError, DatabaseError
 
 from mkts_backend.config.logging_config import configure_logging
 from mkts_backend.config import DatabaseConfig
+from mkts_backend.config.market_context import MarketContext
 from mkts_backend.utils.eft_parser import parse_eft_file, parse_eft_string
 from mkts_backend.utils.doctrine_update import (
     update_fit_market_flag,
@@ -70,17 +71,62 @@ console = Console()
 def _configured_market_db_aliases() -> List[str]:
     """Return the per-market database aliases from settings.toml.
 
-    Resolves each configured market via MarketContext so callers never
-    hardcode "wcmktprod"/"wcmktnorth" (or the legacy "wcmkt" catch-all).
+    Callers should use this instead of naming market DB aliases inline,
+    which would silently miss markets added later.
     """
-    from mkts_backend.config.market_context import MarketContext
-
     aliases: List[str] = []
     for market in MarketContext.list_available():
-        db_alias = MarketContext.from_settings(market).database_alias
+        try:
+            db_alias = MarketContext.from_settings(market).database_alias
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to resolve DB alias for market '{market}' while "
+                f"enumerating configured markets: {e}"
+            ) from e
         if db_alias not in aliases:
             aliases.append(db_alias)
     return aliases
+
+
+def _discover_fits_across_markets(
+    doctrine_id: int, remote: bool
+) -> tuple[List[int], List[str], List[tuple[str, str]]]:
+    """Query every configured market for fits in ``doctrine_id``.
+
+    Returns ``(fit_ids, queried_aliases, skipped)`` where ``skipped`` pairs an
+    alias with the error message that caused it to be excluded. Per-alias
+    failures are logged and skipped so a single unreachable DB does not
+    abort an otherwise-serviceable assign/unassign.
+    """
+    fit_ids: List[int] = []
+    queried: List[str] = []
+    skipped: List[tuple[str, str]] = []
+    for source_alias in _configured_market_db_aliases():
+        try:
+            rows = get_doctrine_fits_from_market(doctrine_id, source_alias, remote)
+        except Exception as e:
+            logger.warning(
+                "Skipping market '%s' during fit discovery for doctrine %s: %s",
+                source_alias, doctrine_id, e,
+            )
+            skipped.append((source_alias, str(e)))
+            continue
+        queried.append(source_alias)
+        for fid in rows:
+            if fid not in fit_ids:
+                fit_ids.append(fid)
+    return fit_ids, queried, skipped
+
+
+def _render_no_fits_message(doctrine_id: int, queried: List[str], skipped: List[tuple[str, str]]) -> None:
+    """Render the 'no fits found' warning, distinguishing queried vs skipped."""
+    parts = [f"No fits found for doctrine {doctrine_id}"]
+    if queried:
+        parts.append(f"in ({', '.join(queried)})")
+    if skipped:
+        skipped_str = ", ".join(f"{a}: {msg}" for a, msg in skipped)
+        parts.append(f"(skipped: {skipped_str})")
+    console.print(f"[yellow]{' '.join(parts)}[/yellow]")
 
 
 def get_available_doctrines(remote: bool = False) -> List[dict]:
@@ -638,20 +684,11 @@ def assign_doctrine_market(
         )
         return False
 
-    # Discover fits across every configured market, not just the destination.
-    # Otherwise assigning a doctrine to a market where it doesn't yet exist
-    # (the exact reason this command is usually invoked) would bail here.
-    fit_ids: List[int] = []
-    searched_aliases = _configured_market_db_aliases()
-    for source_alias in searched_aliases:
-        for fid in get_doctrine_fits_from_market(doctrine_id, source_alias, remote):
-            if fid not in fit_ids:
-                fit_ids.append(fid)
+    # Discover fits across every configured market, not just the destination,
+    # so assign works when the doctrine exists only in a non-target DB.
+    fit_ids, queried_aliases, skipped = _discover_fits_across_markets(doctrine_id, remote)
     if not fit_ids:
-        console.print(
-            f"[yellow]No fits found for doctrine {doctrine_id} in any configured market "
-            f"({', '.join(searched_aliases)})[/yellow]"
-        )
+        _render_no_fits_message(doctrine_id, queried_aliases, skipped)
         return False
 
     # Get doctrine name for display
@@ -1275,19 +1312,10 @@ def unassign_doctrine_market(
         )
         return False
 
-    # Discover fits across every configured market so unassign can act on
-    # doctrines that live only in the non-target DB (symmetric with assign).
-    fit_ids: List[int] = []
-    searched_aliases = _configured_market_db_aliases()
-    for source_alias in searched_aliases:
-        for fid in get_doctrine_fits_from_market(doctrine_id, source_alias, remote):
-            if fid not in fit_ids:
-                fit_ids.append(fid)
+    # Symmetric with assign: discover fits across every configured market.
+    fit_ids, queried_aliases, skipped = _discover_fits_across_markets(doctrine_id, remote)
     if not fit_ids:
-        console.print(
-            f"[yellow]No fits found for doctrine {doctrine_id} in any configured market "
-            f"({', '.join(searched_aliases)})[/yellow]"
-        )
+        _render_no_fits_message(doctrine_id, queried_aliases, skipped)
         return False
 
     # Get doctrine name for display

--- a/src/mkts_backend/cli_tools/fit_update.py
+++ b/src/mkts_backend/cli_tools/fit_update.py
@@ -67,6 +67,22 @@ logger = configure_logging(__name__)
 console = Console()
 
 
+def _configured_market_db_aliases() -> List[str]:
+    """Return the per-market database aliases from settings.toml.
+
+    Resolves each configured market via MarketContext so callers never
+    hardcode "wcmktprod"/"wcmktnorth" (or the legacy "wcmkt" catch-all).
+    """
+    from mkts_backend.config.market_context import MarketContext
+
+    aliases: List[str] = []
+    for market in MarketContext.list_available():
+        db_alias = MarketContext.from_settings(market).database_alias
+        if db_alias not in aliases:
+            aliases.append(db_alias)
+    return aliases
+
+
 def get_available_doctrines(remote: bool = False) -> List[dict]:
     """Get list of available doctrines from fittings database."""
     db = DatabaseConfig("fittings")
@@ -622,10 +638,19 @@ def assign_doctrine_market(
         )
         return False
 
-    fit_ids = get_doctrine_fits_from_market(doctrine_id, db_alias, remote)
+    # Discover fits across every configured market, not just the destination.
+    # Otherwise assigning a doctrine to a market where it doesn't yet exist
+    # (the exact reason this command is usually invoked) would bail here.
+    fit_ids: List[int] = []
+    searched_aliases = _configured_market_db_aliases()
+    for source_alias in searched_aliases:
+        for fid in get_doctrine_fits_from_market(doctrine_id, source_alias, remote):
+            if fid not in fit_ids:
+                fit_ids.append(fid)
     if not fit_ids:
         console.print(
-            f"[yellow]No fits found for doctrine {doctrine_id} in {db_alias}[/yellow]"
+            f"[yellow]No fits found for doctrine {doctrine_id} in any configured market "
+            f"({', '.join(searched_aliases)})[/yellow]"
         )
         return False
 
@@ -1250,9 +1275,19 @@ def unassign_doctrine_market(
         )
         return False
 
-    fit_ids = get_doctrine_fits_from_market(doctrine_id, db_alias, remote)
+    # Discover fits across every configured market so unassign can act on
+    # doctrines that live only in the non-target DB (symmetric with assign).
+    fit_ids: List[int] = []
+    searched_aliases = _configured_market_db_aliases()
+    for source_alias in searched_aliases:
+        for fid in get_doctrine_fits_from_market(doctrine_id, source_alias, remote):
+            if fid not in fit_ids:
+                fit_ids.append(fid)
     if not fit_ids:
-        console.print(f"[yellow]No fits found for doctrine {doctrine_id} in {db_alias}[/yellow]")
+        console.print(
+            f"[yellow]No fits found for doctrine {doctrine_id} in any configured market "
+            f"({', '.join(searched_aliases)})[/yellow]"
+        )
         return False
 
     # Get doctrine name for display

--- a/tests/test_fit_update_assign.py
+++ b/tests/test_fit_update_assign.py
@@ -1,0 +1,134 @@
+"""Tests for cross-market fit discovery used by assign/unassign-market.
+
+The fix in PR #24 made ``assign_doctrine_market`` and
+``unassign_doctrine_market`` search for fits across *every* configured
+market rather than only the destination DB. These tests lock in that
+behavior (and its error-handling semantics) at the ``fit_update`` module
+boundary so regressions are caught without spinning real databases.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from mkts_backend.cli_tools import fit_update
+
+
+@pytest.fixture
+def patched_aliases():
+    """Patch _configured_market_db_aliases to a known two-market set."""
+    with patch.object(
+        fit_update, "_configured_market_db_aliases",
+        return_value=["wcmktprod", "wcmktnorth"],
+    ):
+        yield
+
+
+class TestConfiguredMarketDbAliases:
+    def test_dedupes_shared_database_alias(self):
+        """If two markets resolve to the same DB alias, return one entry."""
+        class FakeCtx:
+            def __init__(self, alias): self.database_alias = alias
+        with patch.object(fit_update.MarketContext, "list_available",
+                          return_value=["primary", "deployment"]):
+            with patch.object(fit_update.MarketContext, "from_settings",
+                              side_effect=lambda m: FakeCtx("wcmktprod")):
+                assert fit_update._configured_market_db_aliases() == ["wcmktprod"]
+
+    def test_empty_list_available(self):
+        """No markets configured -> empty alias list, no exception."""
+        with patch.object(fit_update.MarketContext, "list_available", return_value=[]):
+            assert fit_update._configured_market_db_aliases() == []
+
+    def test_wraps_resolution_failure_with_context(self):
+        """MarketContext errors get wrapped so the user sees which market broke."""
+        with patch.object(fit_update.MarketContext, "list_available",
+                          return_value=["broken"]):
+            with patch.object(fit_update.MarketContext, "from_settings",
+                              side_effect=KeyError("missing")):
+                with pytest.raises(RuntimeError, match="broken"):
+                    fit_update._configured_market_db_aliases()
+
+
+class TestDiscoverFitsAcrossMarkets:
+    def test_dedup_across_overlapping_markets(self, patched_aliases):
+        """Same fit_id returned by both markets appears once."""
+        with patch.object(fit_update, "get_doctrine_fits_from_market",
+                          return_value=[101, 102]):
+            fit_ids, queried, skipped = fit_update._discover_fits_across_markets(7, False)
+        assert fit_ids == [101, 102]
+        assert queried == ["wcmktprod", "wcmktnorth"]
+        assert skipped == []
+
+    def test_finds_fits_in_non_destination_market(self, patched_aliases):
+        """Fits live only in wcmktnorth -> still discovered."""
+        def fake(doctrine_id, alias, remote):
+            return [201, 202] if alias == "wcmktnorth" else []
+        with patch.object(fit_update, "get_doctrine_fits_from_market", side_effect=fake):
+            fit_ids, queried, _ = fit_update._discover_fits_across_markets(7, False)
+        assert fit_ids == [201, 202]
+        assert set(queried) == {"wcmktprod", "wcmktnorth"}
+
+    def test_one_unreachable_market_skipped_not_fatal(self, patched_aliases):
+        """If one DB raises, discovery continues with the other."""
+        def fake(doctrine_id, alias, remote):
+            if alias == "wcmktprod":
+                raise RuntimeError("connection refused")
+            return [301]
+        with patch.object(fit_update, "get_doctrine_fits_from_market", side_effect=fake):
+            fit_ids, queried, skipped = fit_update._discover_fits_across_markets(7, False)
+        assert fit_ids == [301]
+        assert queried == ["wcmktnorth"]
+        assert len(skipped) == 1
+        assert skipped[0][0] == "wcmktprod"
+        assert "connection refused" in skipped[0][1]
+
+
+class TestAssignDoctrineMarketCrossMarket:
+    def test_proceeds_when_fits_only_in_non_target_db(self, patched_aliases):
+        """Regression guard: pre-fix code bailed here because it searched
+        only the destination DB. Assert the function makes it past discovery."""
+        def fake_fits(doctrine_id, alias, remote):
+            return [42] if alias == "wcmktnorth" else []
+        with patch.object(fit_update, "get_doctrine_fits_from_market", side_effect=fake_fits), \
+             patch.object(fit_update, "get_available_doctrines", return_value=[{"id": 7, "name": "Test"}]), \
+             patch.object(fit_update, "_get_doctrine_fits_rows", return_value=[]):
+            result = fit_update.assign_doctrine_market(
+                doctrine_id=7, market_flag="primary", remote=False,
+                db_alias="wcmktprod",
+            )
+        # Returns False because _get_doctrine_fits_rows is empty, but importantly
+        # we got past the discovery bail-out — i.e. the cross-market search worked.
+        assert result is False
+
+
+class TestUnassignDoctrineMarketCrossMarket:
+    def test_proceeds_when_fits_only_in_non_target_db(self, patched_aliases):
+        def fake_fits(doctrine_id, alias, remote):
+            return [42] if alias == "wcmktnorth" else []
+        with patch.object(fit_update, "get_doctrine_fits_from_market", side_effect=fake_fits), \
+             patch.object(fit_update, "get_available_doctrines", return_value=[{"id": 7, "name": "Test"}]), \
+             patch.object(fit_update, "_get_doctrine_fits_rows", return_value=[]):
+            result = fit_update.unassign_doctrine_market(
+                doctrine_id=7, market_to_remove="primary", remote=False,
+                db_alias="wcmktprod",
+            )
+        assert result is False
+
+
+class TestNoFitsMessage:
+    def test_includes_queried_aliases(self, capsys):
+        fit_update._render_no_fits_message(7, ["wcmktprod", "wcmktnorth"], [])
+        out = capsys.readouterr().out
+        assert "wcmktprod" in out and "wcmktnorth" in out
+        assert "skipped" not in out.lower()
+
+    def test_reports_skipped_separately(self, capsys):
+        fit_update._render_no_fits_message(
+            7, ["wcmktprod"], [("wcmktnorth", "connection refused")],
+        )
+        out = capsys.readouterr().out
+        assert "wcmktprod" in out
+        assert "skipped" in out.lower()
+        assert "wcmktnorth" in out
+        # Rich may insert soft wraps in long output; normalize whitespace.
+        assert "connection refused" in " ".join(out.split())


### PR DESCRIPTION
## Summary
- `fit-update assign-market --doctrine-id=N --market=deployment` used to search only the destination DB for doctrine N's fits, so propagating a doctrine from primary to deployment always bailed with "no fits found" — the exact case the command exists to handle.
- `unassign-market` had the identical bug. Both now union fit_ids across every market configured in `settings.toml`, resolved via `MarketContext`.
- New local helper `_configured_market_db_aliases()` pulls db_aliases from settings rather than hardcoding `wcmktprod`/`wcmktnorth`. No `"wcmkt"` catch-all reintroduced.

Scope intentionally narrow: legacy `MARKET_DB_MAP`, `target_alias="wcmkt"` defaults, `_flag_to_aliases`'s hardcoded tuple, and the per-fit fallback inside `_get_doctrine_fits_rows` callers are left for a follow-up explicit-alias refactor.

## Test plan
- [x] `fit-update assign-market --doctrine-id=95 --market=deployment` now propagates primary-only doctrine to deployment (verified by @OrthelT)
- [ ] `fit-update assign-market --doctrine-id=<primary-only> --market=primary` still a no-op
- [ ] `fit-update unassign-market --doctrine-id=<deployment-only> --market=deployment` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)