### PR TITLE
feat: quick build cost estimation task

### DIFF
--- a/.github/workflows/builder-costs-collection.yml
+++ b/.github/workflows/builder-costs-collection.yml
@@ -46,7 +46,7 @@ jobs:
           TURSO_SDE_TOKEN: ${{ secrets.TURSO_SDE_TOKEN }}
       - name: Save cached databases
         uses: actions/cache/save@v4
-        if: always()
+        if: success()
         with:
           path: |
             sdelite.db

--- a/.github/workflows/builder-costs-collection.yml
+++ b/.github/workflows/builder-costs-collection.yml
@@ -1,0 +1,66 @@
+name: Builder Costs Collection
+
+on:
+  schedule:
+    - cron: '45 */6 * * *'
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  collect-builder-costs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+      - run: uv sync
+      - run: uv pip install -e .
+      - run: mkdir -p logs data databackup
+      - name: Restore cached databases
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            sdelite.db
+            sdelite.db-info
+            wcfitting.db
+            wcfitting.db-info
+            wcmktprod.db
+            wcmktprod.db-info
+            wcmktnorth2.db
+            wcmktnorth2.db-info
+          key: builder-cost-dbs-v1-${{ github.run_id }}
+          restore-keys: |
+            builder-cost-dbs-v1-
+      - name: Run builder costs collection
+        run: uv run mkts-backend update-builder-costs
+        env:
+          TURSO_WCMKTPROD_URL: ${{ secrets.TURSO_WCMKTPROD_URL }}
+          TURSO_WCMKTPROD_TOKEN: ${{ secrets.TURSO_WCMKTPROD_TOKEN }}
+          TURSO_WCMKTNORTH_URL: ${{ secrets.TURSO_WCMKTNORTH_URL }}
+          TURSO_WCMKTNORTH_TOKEN: ${{ secrets.TURSO_WCMKTNORTH_TOKEN }}
+          TURSO_SDE_URL: ${{ secrets.TURSO_SDE_URL }}
+          TURSO_SDE_TOKEN: ${{ secrets.TURSO_SDE_TOKEN }}
+      - name: Save cached databases
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          path: |
+            sdelite.db
+            sdelite.db-info
+            wcfitting.db
+            wcfitting.db-info
+            wcmktprod.db
+            wcmktprod.db-info
+            wcmktnorth2.db
+            wcmktnorth2.db-info
+          key: builder-cost-dbs-v1-${{ github.run_id }}
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: builder-costs-logs
+          path: logs/

--- a/docs/builder_costs.md
+++ b/docs/builder_costs.md
@@ -1,0 +1,99 @@
+# Builder Costs Feature
+
+## Overview
+
+The builder costs feature fetches manufacturing cost estimates from Everef for manufacturable watchlist items and stores the results in the backend databases. It is exposed through the `update-builder-costs` command and is intended to support both manual runs and scheduled collection.
+
+The dataset is market-independent, so the command writes the same results to every configured market database.
+
+## What It Collects
+
+For each eligible watchlist item, the pipeline stores:
+
+- `type_id`
+- `total_cost_per_unit`
+- `time_per_unit`
+- `me`
+- `runs`
+- `fetched_at`
+
+These values are persisted in the `builder_costs` table.
+
+## Command Usage
+
+```bash
+# Fetch builder costs for all configured markets
+uv run mkts-backend update-builder-costs
+
+# Alias forms also work
+uv run mkts-backend builder-costs
+uv run mkts-backend ubc
+```
+
+The command does not take item filters. It inspects the configured market databases, reads their watchlists, and fetches cost data for the eligible items automatically.
+
+## Data Sources
+
+The pipeline combines three inputs:
+
+- Watchlist rows from each configured market database
+- Jita prices from the first available `jita_prices` table
+- SDE metadata from `sdelite.db` to determine which items are manufacturable
+
+The Everef API is then queried asynchronously with controlled concurrency and rate limiting.
+
+## Item Selection Rules
+
+Not every watchlist item is fetched. The async fetch layer filters items using:
+
+- Meta group checks for manufacturable items
+- Category allow-lists
+- Exclusion lists for known unsupported groups and item names
+- Jita price-aware parameter selection for some T2 modules
+
+This keeps collection focused on items that can realistically be modeled as builder costs.
+
+## Database Schema
+
+```sql
+CREATE TABLE builder_costs (
+    type_id INTEGER PRIMARY KEY,
+    total_cost_per_unit REAL,
+    time_per_unit REAL,
+    me INTEGER,
+    runs INTEGER,
+    fetched_at TEXT
+);
+```
+
+The table is treated as a wipe-and-replace dataset, so a fresh fetch replaces the previous contents.
+
+## Collection Flow
+
+1. Initialize and verify all configured market databases.
+2. Sync the databases locally so the current watchlist and Jita price data are available.
+3. Merge watchlist items across markets.
+4. Read the first available `jita_prices` table.
+5. Load SDE metadata from `sdelite.db`.
+6. Fetch builder costs asynchronously from Everef.
+7. Create `builder_costs` if needed.
+8. Replace the table contents in each market database.
+9. Write an update log entry for each successful market write.
+
+## Implementation Notes
+
+- CLI routing is registered in `src/mkts_backend/cli_tools/command_registry.py`.
+- Argument parsing recognizes `update-builder-costs` as a help-aware subcommand.
+- The database model lives in `src/mkts_backend/db/models.py` as `BuilderCosts`.
+- Upsert behavior is handled through the generic database layer in `src/mkts_backend/db/db_handlers.py`.
+- Async Everef fetch logic lives in `src/mkts_backend/esi/async_everref.py`.
+- The main orchestration entry point is `process_builder_costs()` in `src/mkts_backend/cli.py`.
+
+## Scheduled Run
+
+The new GitHub Actions workflow `builder-costs-collection.yml` runs this command on a 6-hour schedule and also supports manual dispatch. It restores cached SQLite databases, runs the collection job, then saves the updated databases and logs.
+
+## Related Docs
+
+- [docs/cli-tools.md](cli-tools.md): Full CLI reference.
+- [docs/doctrine_cli_tools.md](doctrine_cli_tools.md): Broader doctrine tooling notes.

--- a/docs/builder_costs.md
+++ b/docs/builder_costs.md
@@ -58,11 +58,11 @@ This keeps collection focused on items that can realistically be modeled as buil
 ```sql
 CREATE TABLE builder_costs (
     type_id INTEGER PRIMARY KEY,
-    total_cost_per_unit REAL,
-    time_per_unit REAL,
-    me INTEGER,
-    runs INTEGER,
-    fetched_at TEXT
+    total_cost_per_unit FLOAT NOT NULL,
+    time_per_unit FLOAT NOT NULL,
+    me INTEGER NOT NULL,
+    runs INTEGER NOT NULL,
+    fetched_at DATETIME NOT NULL
 );
 ```
 

--- a/docs/builder_costs.md
+++ b/docs/builder_costs.md
@@ -74,7 +74,10 @@ The table is treated as a wipe-and-replace dataset, so a fresh fetch replaces th
 2. Sync the databases locally so the current watchlist and Jita price data are available.
 3. Merge watchlist items across markets.
 4. Read the first available `jita_prices` table.
-5. Load SDE metadata from `sdelite.db`.
+5. Load SDE metadata from `sdelite.db`. Items without a manufacturing blueprint
+   (`industryActivityProducts.activityID = 1`) are filtered out here so we
+   don't waste rate-limited Everef requests on meta-T1 NPC drops and other
+   non-buildable items.
 6. Fetch builder costs asynchronously from Everef.
 7. Create `builder_costs` if needed.
 8. Replace the table contents in each market database.

--- a/src/mkts_backend/cli.py
+++ b/src/mkts_backend/cli.py
@@ -2,10 +2,7 @@ import sys
 import json
 import time
 import os
-from typing import Optional
-
-# Check if terminal output (progress prints) should be suppressed.
-QUIET = os.environ.get("MKTS_QUIET", "0") == "1"
+from typing import Optional, cast
 
 from mkts_backend.config.logging_config import configure_logging
 from mkts_backend.db.db_queries import get_table_length
@@ -15,7 +12,7 @@ from mkts_backend.db.db_handlers import (
     update_market_orders,
     log_update,
 )
-from mkts_backend.db.models import MarketStats, Doctrines, JitaPrices
+from mkts_backend.db.models import MarketStats, Doctrines, JitaPrices, BuilderCosts
 from mkts_backend.utils.utils import (
     validate_columns,
     convert_datetime_columns,
@@ -26,7 +23,10 @@ from mkts_backend.processing.data_processing import (
     calculate_doctrine_stats,
 )
 from mkts_backend.config.esi_config import ESIConfig
-from mkts_backend.esi.esi_requests import fetch_market_orders
+from mkts_backend.esi.esi_requests import (
+    fetch_market_orders,
+    FetchMarketOrdersSuccess,
+)
 from mkts_backend.esi.async_history import run_async_history
 from mkts_backend.utils.validation import validate_all
 from mkts_backend.config.db_config import DatabaseConfig
@@ -34,6 +34,9 @@ from mkts_backend.config.settings_service import SettingsService
 from mkts_backend.cli_tools.args_parser import parse_args
 from mkts_backend.config.gsheets_config import GoogleSheetConfig
 from mkts_backend.config.market_context import MarketContext
+
+# Check if terminal output (progress prints) should be suppressed.
+QUIET = os.environ.get("MKTS_QUIET", "0") == "1"
 
 logger = configure_logging(__name__)
 
@@ -84,7 +87,8 @@ def process_market_orders(
         return True
 
     # 200 — process new data
-    data = result["data"]
+    success_result = cast(FetchMarketOrdersSuccess, result)
+    data = success_result["data"]
     save_path = "data/market_orders_new.json"
     if data:
         with open(save_path, "w") as f:
@@ -99,8 +103,8 @@ def process_market_orders(
             # Save new cache entries
             save_orders_cache(
                 structure_id,
-                expires=result.get("expires"),
-                page_etags=result.get("page_etags", {}),
+                expires=success_result["expires"],
+                page_etags=success_result["page_etags"],
                 market_ctx=market_ctx,
             )
             return True
@@ -114,7 +118,7 @@ def process_market_orders(
         return False
 
 
-def process_history(market_ctx: Optional[MarketContext] = None):
+def process_history(market_ctx: Optional[MarketContext] = None) -> bool:
     logger.info("History mode enabled")
     logger.info("Processing history")
     data = run_async_history(market_ctx=market_ctx)
@@ -136,7 +140,7 @@ def process_history(market_ctx: Optional[MarketContext] = None):
             return False
 
 
-def process_market_stats(market_ctx: Optional[MarketContext] = None):
+def process_market_stats(market_ctx: Optional[MarketContext] = None) -> bool:
     logger.info("Calculating market stats")
     logger.info("syncing database")
     db = (
@@ -197,7 +201,7 @@ def process_market_stats(market_ctx: Optional[MarketContext] = None):
         return False
 
 
-def process_doctrine_stats(market_ctx: Optional[MarketContext] = None):
+def process_doctrine_stats(market_ctx: Optional[MarketContext] = None) -> bool:
     logger.info("Calculating doctrines stats")
     logger.info("syncing database")
     db = (
@@ -229,7 +233,7 @@ def process_doctrine_stats(market_ctx: Optional[MarketContext] = None):
         return False
 
 
-def google_sheets_update_workflow(market_ctx: MarketContext):
+def google_sheets_update_workflow(market_ctx: MarketContext) -> None:
     """Update Google Sheets with market data for the given market context."""
     google_sheet_config = GoogleSheetConfig(market_context=market_ctx)
     worksheets = market_ctx.gsheets_worksheets
@@ -256,7 +260,7 @@ def update_google_sheet(
     sheet_name: str,
     table_name: str,
     market_ctx: Optional[MarketContext] = None,
-):
+) -> None:
     import pandas as pd
 
     db = (
@@ -328,6 +332,138 @@ def process_jita_prices(market_contexts: list[MarketContext]) -> bool:
             logger.error(f"Failed to update Jita prices for {ctx.alias}: {e}")
 
     return any_success
+
+
+def _ensure_builder_costs_table(market_ctx: MarketContext) -> None:
+    """Create the builder_costs table on the remote DB if it doesn't exist."""
+    db = DatabaseConfig(market_context=market_ctx)
+    engine = db.remote_engine
+    try:
+        BuilderCosts.__table__.create(engine, checkfirst=True)
+    finally:
+        engine.dispose()
+
+
+def process_builder_costs(market_contexts: list[MarketContext]) -> bool:
+    """Fetch EverRef builder costs once, write to all configured market databases."""
+    import pandas as pd
+    from sqlalchemy import text
+    from sqlalchemy.exc import SQLAlchemyError
+
+    from mkts_backend.esi.async_everref import run_async_fetch_builder_costs
+
+    available_contexts: list[MarketContext] = []
+    for ctx in market_contexts:
+        db = DatabaseConfig(market_context=ctx)
+        try:
+            if not db.verify_db_exists():
+                logger.error(f"Database verification failed for {ctx.alias}")
+                return False
+            db.sync()
+            available_contexts.append(ctx)
+        except Exception as exc:
+            logger.error(f"Failed to prepare database for {ctx.alias}: {exc}")
+            return False
+        finally:
+            db.engine.dispose()
+
+    if not available_contexts:
+        logger.warning("No market databases available for builder cost collection")
+        return False
+
+    watchlist_rows: dict[int, dict[str, object]] = {}
+    for ctx in available_contexts:
+        db = DatabaseConfig(market_context=ctx)
+        try:
+            watchlist = db.get_watchlist()
+        except SQLAlchemyError as exc:
+            logger.error(f"Failed to read watchlist for {ctx.alias}: {exc}")
+            return False
+        finally:
+            db.engine.dispose()
+
+        if watchlist.empty:
+            continue
+
+        for row in watchlist[
+            ["type_id", "type_name", "group_name", "category_id"]
+        ].drop_duplicates(subset=["type_id"]).to_dict(orient="records"):
+            type_id = int(row["type_id"])
+            watchlist_rows.setdefault(
+                type_id,
+                {
+                    "type_id": type_id,
+                    "type_name": row.get("type_name"),
+                    "group_name": row.get("group_name"),
+                    "category_id": int(row["category_id"])
+                    if pd.notna(row.get("category_id"))
+                    else None,
+                },
+            )
+
+    if not watchlist_rows:
+        logger.warning("No watchlist items found for builder cost fetch")
+        return False
+
+    jita_price_map: dict[int, float] = {}
+    for ctx in available_contexts:
+        db = DatabaseConfig(market_context=ctx)
+        try:
+            with db.engine.connect() as conn:
+                jita_df = pd.read_sql_query(
+                    text("SELECT type_id, sell_price FROM jita_prices"),
+                    conn,
+                )
+            jita_price_map = {
+                int(row.type_id): float(row.sell_price)
+                for row in jita_df.itertuples(index=False)
+                if pd.notna(row.sell_price)
+            }
+            if jita_price_map:
+                break
+        except SQLAlchemyError as exc:
+            logger.warning(
+                f"Failed to read Jita prices from {ctx.alias}; continuing with empty map: {exc}"
+            )
+        finally:
+            db.engine.dispose()
+
+    sde_db = DatabaseConfig("sde")
+    sde_engine = sde_db.engine
+    try:
+        results = run_async_fetch_builder_costs(
+            list(watchlist_rows.keys()),
+            jita_price_map,
+            sde_engine,
+            watchlist_metadata=watchlist_rows,
+        )
+    finally:
+        sde_engine.dispose()
+
+    if not results:
+        logger.warning("No builder cost data returned")
+        return False
+
+    df = pd.DataFrame(results)
+
+    all_success = True
+    for ctx in available_contexts:
+        try:
+            _ensure_builder_costs_table(ctx)
+            valid_columns = BuilderCosts.__table__.columns.keys()
+            builder_df = validate_columns(df, valid_columns)
+            status = upsert_database(BuilderCosts, builder_df, market_ctx=ctx)
+            if status:
+                log_update("builder_costs", remote=True, market_ctx=ctx)
+                logger.info(f"Builder costs updated for {ctx.alias}: {len(builder_df)} items")
+            else:
+                logger.error(f"Failed to update builder costs for {ctx.alias}")
+                all_success = False
+        except SQLAlchemyError as exc:
+            logger.error(f"Failed to update builder costs for {ctx.alias}: {exc}")
+            all_success = False
+
+    return all_success
 
 
 def _run_market_pipeline(
@@ -497,7 +633,7 @@ def run_market_update(history: bool = False, market_alias: str = "both") -> bool
     return True
 
 
-def main():
+def main() -> None:
     """Entry point for the `mkts-backend` CLI.
 
     Bare invocation prints help. Any subcommand is dispatched via the shared

--- a/src/mkts_backend/cli.py
+++ b/src/mkts_backend/cli.py
@@ -364,8 +364,6 @@ def process_builder_costs(market_contexts: list[MarketContext]) -> bool:
         except Exception as exc:
             logger.error(f"Failed to prepare database for {ctx.alias}: {exc}")
             return False
-        finally:
-            db.engine.dispose()
 
     if not available_contexts:
         logger.warning("No market databases available for builder cost collection")
@@ -379,8 +377,6 @@ def process_builder_costs(market_contexts: list[MarketContext]) -> bool:
         except SQLAlchemyError as exc:
             logger.error(f"Failed to read watchlist for {ctx.alias}: {exc}")
             return False
-        finally:
-            db.engine.dispose()
 
         if watchlist.empty:
             continue
@@ -425,8 +421,6 @@ def process_builder_costs(market_contexts: list[MarketContext]) -> bool:
             logger.warning(
                 f"Failed to read Jita prices from {ctx.alias}; continuing with empty map: {exc}"
             )
-        finally:
-            db.engine.dispose()
 
     sde_db = DatabaseConfig("sde")
     sde_engine = sde_db.engine

--- a/src/mkts_backend/cli_tools/args_parser.py
+++ b/src/mkts_backend/cli_tools/args_parser.py
@@ -14,7 +14,13 @@ logger = configure_logging(__name__)
 _VALID_ENVIRONMENTS = ("production", "development")
 
 # Subcommands that have their own --help handling
-_SUBCOMMANDS_WITH_HELP = {"fit-check", "fit-update", "update-fit", "update-target"}
+_SUBCOMMANDS_WITH_HELP = {
+    "fit-check",
+    "fit-update",
+    "update-fit",
+    "update-target",
+    "update-builder-costs",
+}
 
 
 def parse_args(args: list[str]) -> dict | None:

--- a/src/mkts_backend/cli_tools/command_registry.py
+++ b/src/mkts_backend/cli_tools/command_registry.py
@@ -16,7 +16,10 @@ Handlers return ``True`` on success, ``False`` on failure.  They should
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Callable
+from typing import Callable, TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from mkts_backend.utils.parse_fits import FitMetadata
 
 HandlerFn = Callable[[list[str], str], bool]
 
@@ -321,12 +324,14 @@ def _register_all(reg: CommandRegistry) -> None:
         dry_run = p.has_flag("dry-run")
 
         try:
+            metadata: FitMetadata | None = None
+            metadata_dict: dict[str, Any] | None = None
             if meta_file:
                 metadata = parse_fit_metadata(meta_file)
                 if fit_id is not None and metadata.fit_id != fit_id:
                     print(
-                        f"Warning: --fit-id={fit_id} overrides fit_id={
-                            metadata.fit_id} from metadata file"
+                        f"Warning: --fit-id={fit_id} overrides "
+                        f"fit_id={metadata.fit_id} from metadata file"
                     )
                     metadata_dict = {
                         "fit_id": fit_id,
@@ -337,8 +342,6 @@ def _register_all(reg: CommandRegistry) -> None:
                         else metadata.doctrine_id,
                         "target": metadata.target,
                     }
-                else:
-                    metadata_dict = None
             else:
                 from mkts_backend.cli_tools.fit_update import collect_fit_metadata_interactive
                 metadata_dict = collect_fit_metadata_interactive(fit_id, fit_file)
@@ -347,10 +350,13 @@ def _register_all(reg: CommandRegistry) -> None:
                 target_alias = MARKET_DB_MAP[target_market]
                 print(f"\n--- Processing for {target_market} market ({target_alias}) ---")
 
-                if metadata_dict:
+                if metadata_dict is not None:
                     from mkts_backend.utils.parse_fits import FitMetadata
                     metadata_obj = FitMetadata(**metadata_dict)
                 else:
+                    if metadata is None:
+                        print("Error: No fit metadata available for update-fit")
+                        return False
                     metadata_obj = metadata
 
                 result = update_fit_workflow(
@@ -540,6 +546,44 @@ def _register_all(reg: CommandRegistry) -> None:
         return all_valid
 
     reg.register("validate", _handle_validate, description="Validate the database sync status")
+
+    # ── update-builder-costs ───────────────────────────────────
+    def _handle_update_builder_costs(args: list[str], market_alias: str) -> bool:
+        from mkts_backend.cli_tools.arg_utils import ParsedArgs
+        from mkts_backend.config.market_context import MarketContext
+        from mkts_backend.cli import process_builder_costs, init_databases
+
+        p = ParsedArgs(args)
+        if p.has_help():
+            print(
+                "update-builder-costs: Fetch EverRef manufacturing costs for all watchlist items\n"
+                "Usage: mkts-backend update-builder-costs\n"
+                "Build costs are market-independent; written to all configured market DBs."
+            )
+            return True
+
+        init_databases()
+
+        all_ctxs = []
+        for alias in MarketContext.list_available():
+            try:
+                all_ctxs.append(MarketContext.from_settings(alias))
+            except (ValueError, KeyError):
+                pass
+
+        if not all_ctxs:
+            print("Error: No market contexts configured")
+            return False
+
+        return process_builder_costs(market_contexts=all_ctxs)
+
+    reg.register(
+        "update-builder-costs",
+        _handle_update_builder_costs,
+        aliases=["builder-costs", "ubc"],
+        description="Fetch EverRef manufacturing costs for watchlist items",
+        default_market="primary",
+    )
 
     # ── update-markets ──────────────────────────────────────────
     def _handle_update_markets(args: list[str], market_alias: str) -> bool:

--- a/src/mkts_backend/config/settings.toml
+++ b/src/mkts_backend/config/settings.toml
@@ -111,7 +111,7 @@ default_worksheet = ""  # empty = first worksheet in the spreadsheet
 # options = ["marketstats", "doctrines", "jita_prices", "marketorders", "market_history"]
 
 [wipe_replace]
-tables = ["marketstats", "doctrines", "jita_prices"]
+tables = ["marketstats", "doctrines", "jita_prices", "builder_costs"]
 
 
 # ============================================================================

--- a/src/mkts_backend/db/db_handlers.py
+++ b/src/mkts_backend/db/db_handlers.py
@@ -5,8 +5,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from dotenv import load_dotenv
 from datetime import datetime, timezone
-from typing import Optional, TYPE_CHECKING
-import time
+from typing import Optional, TYPE_CHECKING, TypeVar
 import numpy as np
 import os
 import json
@@ -18,7 +17,7 @@ from mkts_backend.utils.utils import (
     get_type_names_from_df,
 )
 from mkts_backend.config.logging_config import configure_logging
-from mkts_backend.db.models import Base, MarketHistory, MarketOrders, UpdateLog, ESIRequestCache
+from mkts_backend.db.models import Base, MarketHistory, MarketOrders, UpdateLog
 from mkts_backend.config.db_config import DatabaseConfig
 from mkts_backend.config.settings_service import SettingsService
 from mkts_backend.db.db_queries import get_table_length, get_remote_status
@@ -33,6 +32,7 @@ QUIET = os.environ.get("MKTS_QUIET", "0") == "1"
 # Lazy initialization - these will be initialized on first use or via market_ctx
 _db = None
 _sde_db = None
+TableModel = TypeVar("TableModel", bound=Base)
 
 def _get_db(market_ctx: Optional["MarketContext"] = None) -> DatabaseConfig:
     """Get database config, optionally using market context."""
@@ -119,7 +119,7 @@ def handle_nulls(df: pd.DataFrame, tabname: str) -> pd.DataFrame:
     return df
 
 def upsert_database(
-    table: Base,
+    table: type[TableModel],
     df: pd.DataFrame,
     market_ctx: Optional["MarketContext"] = None
 ) -> bool:

--- a/src/mkts_backend/db/models.py
+++ b/src/mkts_backend/db/models.py
@@ -207,16 +207,18 @@ class JitaPrices(Base):
 class BuilderCosts(Base):
     __tablename__ = "builder_costs"
     type_id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    total_cost_per_unit: Mapped[float] = mapped_column(Float, nullable=True)
-    time_per_unit: Mapped[float] = mapped_column(Float, nullable=True)
-    me: Mapped[int] = mapped_column(Integer, nullable=True)
-    runs: Mapped[int] = mapped_column(Integer, nullable=True)
-    fetched_at: Mapped[str] = mapped_column(String, nullable=True)
+    total_cost_per_unit: Mapped[float] = mapped_column(Float)
+    time_per_unit: Mapped[float] = mapped_column(Float)
+    me: Mapped[int] = mapped_column(Integer)
+    runs: Mapped[int] = mapped_column(Integer)
+    fetched_at: Mapped[DateTime] = mapped_column(DateTime)
 
     def __repr__(self) -> str:
         return (
             f"BuilderCosts(type_id={self.type_id!r}, "
-            f"total_cost_per_unit={self.total_cost_per_unit!r})"
+            f"total_cost_per_unit={self.total_cost_per_unit!r}, "
+            f"time_per_unit={self.time_per_unit!r}, me={self.me!r}, "
+            f"runs={self.runs!r}, fetched_at={self.fetched_at!r})"
         )
 
 

--- a/src/mkts_backend/db/models.py
+++ b/src/mkts_backend/db/models.py
@@ -204,6 +204,22 @@ class JitaPrices(Base):
         )
 
 
+class BuilderCosts(Base):
+    __tablename__ = "builder_costs"
+    type_id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    total_cost_per_unit: Mapped[float] = mapped_column(Float, nullable=True)
+    time_per_unit: Mapped[float] = mapped_column(Float, nullable=True)
+    me: Mapped[int] = mapped_column(Integer, nullable=True)
+    runs: Mapped[int] = mapped_column(Integer, nullable=True)
+    fetched_at: Mapped[str] = mapped_column(String, nullable=True)
+
+    def __repr__(self) -> str:
+        return (
+            f"BuilderCosts(type_id={self.type_id!r}, "
+            f"total_cost_per_unit={self.total_cost_per_unit!r})"
+        )
+
+
 class ModuleEquivalents(Base):
     """
     Maps equivalent faction modules that can be used interchangeably.

--- a/src/mkts_backend/esi/async_everref.py
+++ b/src/mkts_backend/esi/async_everref.py
@@ -9,7 +9,7 @@ from aiolimiter import AsyncLimiter
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
 
-from mkts_backend.config.esi_config import ESIConfig
+from mkts_backend.config.settings_service import SettingsService
 from mkts_backend.config.logging_config import configure_logging
 
 logger = configure_logging(__name__)
@@ -211,7 +211,7 @@ async def async_fetch_builder_costs(
 
     semaphore = asyncio.Semaphore(MAX_CONCURRENCY)
     limiter = AsyncLimiter(30, time_period=60.0)
-    headers = {"User-Agent": ESIConfig("primary").user_agent}
+    headers = {"User-Agent": SettingsService().esi_user_agent}
 
     async with httpx.AsyncClient(http2=True, headers=headers) as client:
         results = await asyncio.gather(

--- a/src/mkts_backend/esi/async_everref.py
+++ b/src/mkts_backend/esi/async_everref.py
@@ -102,6 +102,14 @@ _META_GROUP_CHUNK_SIZE = 500  # keep well under libsql/sqlite var limits (matche
 
 
 def _get_meta_groups(type_ids: list[int], sde_engine: Engine) -> dict[int, int]:
+    """Return meta_group_id only for type_ids that are produced by a manufacturing blueprint.
+
+    Inner-joins `industryActivityProducts` (activityID=1) so meta-level T1 NPC
+    drops (e.g. "Compact"/"Enduring"/"Scoped" modules) are filtered out before
+    we waste EverRef requests that would return HTTP 400 "not produced from a
+    blueprint". Items missing from the SDE or without a blueprint are absent
+    from the returned dict.
+    """
     if not type_ids:
         return {}
 
@@ -112,7 +120,13 @@ def _get_meta_groups(type_ids: list[int], sde_engine: Engine) -> dict[int, int]:
             placeholders = ", ".join(f":type_id_{index}" for index, _ in enumerate(chunk))
             params = {f"type_id_{index}": type_id for index, type_id in enumerate(chunk)}
             query = text(
-                f"SELECT typeID, metaGroupID FROM sdetypes WHERE typeID IN ({placeholders})"
+                f"""
+                SELECT s.typeID, s.metaGroupID
+                FROM sdetypes s
+                INNER JOIN industryActivityProducts iap
+                  ON iap.productTypeID = s.typeID AND iap.activityID = 1
+                WHERE s.typeID IN ({placeholders})
+                """
             )
             for row in conn.execute(query, params).mappings():
                 type_id = row.get("typeID")
@@ -197,6 +211,12 @@ async def async_fetch_builder_costs(
 ) -> list[BuilderCostRecord]:
     watchlist_metadata = watchlist_metadata or {}
     meta_groups = _get_meta_groups(type_ids, sde_engine)
+    unbuildable = len(type_ids) - len(meta_groups)
+    if unbuildable:
+        logger.info(
+            f"Filtered {unbuildable}/{len(type_ids)} watchlist items "
+            "with no manufacturing blueprint in the SDE"
+        )
 
     fetch_jobs: list[tuple[int, int, int]] = []
     for type_id in type_ids:

--- a/src/mkts_backend/esi/async_everref.py
+++ b/src/mkts_backend/esi/async_everref.py
@@ -49,10 +49,10 @@ class WatchlistMetadata(TypedDict):
 class BuilderCostRecord(TypedDict):
     type_id: int
     total_cost_per_unit: float
-    time_per_unit: float | None
+    time_per_unit: float
     me: int
     runs: int
-    fetched_at: str
+    fetched_at: datetime
 
 
 def _parse_iso_duration(value: str | None) -> float | None:
@@ -98,26 +98,29 @@ def _resolve_api_params(
     return (0, 1)
 
 
+_META_GROUP_CHUNK_SIZE = 500  # keep well under libsql/sqlite var limits (matches db_handlers)
+
+
 def _get_meta_groups(type_ids: list[int], sde_engine: Engine) -> dict[int, int]:
     if not type_ids:
         return {}
 
-    placeholders = ", ".join(f":type_id_{index}" for index, _ in enumerate(type_ids))
-    params = {f"type_id_{index}": type_id for index, type_id in enumerate(type_ids)}
-    query = text(
-        f"SELECT typeID, metaGroupID FROM sdetypes WHERE typeID IN ({placeholders})"
-    )
-
+    meta_groups: dict[int, int] = {}
     with sde_engine.connect() as conn:
-        result = conn.execute(query, params)
-        meta_groups: dict[int, int] = {}
-        for row in result.mappings():
-            type_id = row.get("typeID")
-            meta_group_id = row.get("metaGroupID")
-            if type_id is None or meta_group_id is None:
-                continue
-            meta_groups[int(type_id)] = int(meta_group_id)
-        return meta_groups
+        for start in range(0, len(type_ids), _META_GROUP_CHUNK_SIZE):
+            chunk = type_ids[start : start + _META_GROUP_CHUNK_SIZE]
+            placeholders = ", ".join(f":type_id_{index}" for index, _ in enumerate(chunk))
+            params = {f"type_id_{index}": type_id for index, type_id in enumerate(chunk)}
+            query = text(
+                f"SELECT typeID, metaGroupID FROM sdetypes WHERE typeID IN ({placeholders})"
+            )
+            for row in conn.execute(query, params).mappings():
+                type_id = row.get("typeID")
+                meta_group_id = row.get("metaGroupID")
+                if type_id is None or meta_group_id is None:
+                    continue
+                meta_groups[int(type_id)] = int(meta_group_id)
+    return meta_groups
 
 
 def _build_request_url(type_id: int, me: int, runs: int) -> str:
@@ -171,13 +174,18 @@ async def _fetch_one(
         logger.warning(f"EverRef response missing total_cost_per_unit for {type_id}")
         return None
 
+    time_per_unit = _parse_iso_duration(result.get("time_per_unit"))
+    if time_per_unit is None:
+        logger.warning(f"EverRef response missing time_per_unit for {type_id}")
+        return None
+
     return {
         "type_id": type_id,
         "total_cost_per_unit": float(total_cost),
-        "time_per_unit": _parse_iso_duration(result.get("time_per_unit")),
+        "time_per_unit": time_per_unit,
         "me": me,
         "runs": runs,
-        "fetched_at": datetime.now(timezone.utc).isoformat(),
+        "fetched_at": datetime.now(timezone.utc),
     }
 
 

--- a/src/mkts_backend/esi/async_everref.py
+++ b/src/mkts_backend/esi/async_everref.py
@@ -1,0 +1,245 @@
+import asyncio
+import re
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Any, TypedDict
+
+import httpx
+from aiolimiter import AsyncLimiter
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from mkts_backend.config.esi_config import ESIConfig
+from mkts_backend.config.logging_config import configure_logging
+
+logger = configure_logging(__name__)
+
+EVEREF_BASE_URL = "https://api.everef.net/v1/industry/cost"
+EVEREF_STATIC_PARAMS = (
+    "structure_type_id=35826&security=NULL_SEC"
+    "&system_cost_bonus=0&manufacturing_cost=0&facility_tax=0"
+)
+API_TIMEOUT = 20.0
+MAX_CONCURRENCY = 6
+
+MANUFACTURABLE_META_GROUPS = frozenset({1, 2, 14})
+ALLOWED_CATEGORIES = frozenset({7, 18, 8, 6, 87, 22, 32})
+EXCLUDED_GROUPS = frozenset(
+    {"Interdiction Nullifier", "Exotic Plasma Charge", "Condenser Pack"}
+)
+EXCLUDED_NAMES = frozenset({"Vedmak", "Leshak", "Damavik", "Zirnitra"})
+HIGH_VALUE_THRESHOLD = 40_000_000
+T2_MODULE_CATEGORIES = frozenset({7, 18, 8})
+
+DEFAULT_TE = 0
+DEFAULT_MATERIAL_PRICE_SOURCE = "ESI_AVG"
+
+_DURATION_RE = re.compile(
+    r"^P(?:(?P<days>\d+)D)?(?:T(?:(?P<hours>\d+)H)?(?:(?P<minutes>\d+)M)?(?:(?P<seconds>\d+(?:\.\d+)?)S)?)?$"
+)
+
+
+class WatchlistMetadata(TypedDict):
+    type_id: int
+    type_name: str | None
+    group_name: str | None
+    category_id: int | None
+
+
+class BuilderCostRecord(TypedDict):
+    type_id: int
+    total_cost_per_unit: float
+    time_per_unit: float | None
+    me: int
+    runs: int
+    fetched_at: str
+
+
+def _parse_iso_duration(value: str | None) -> float | None:
+    if not value:
+        return None
+
+    match = _DURATION_RE.match(value)
+    if match is None:
+        return None
+
+    days = int(match.group("days") or 0)
+    hours = int(match.group("hours") or 0)
+    minutes = int(match.group("minutes") or 0)
+    seconds = float(match.group("seconds") or 0.0)
+    return float(days * 86400 + hours * 3600 + minutes * 60) + seconds
+
+
+def _resolve_api_params(
+    meta_group_id: int | None,
+    category_id: int | None,
+    group_name: str | None,
+    type_name: str | None,
+    jita_price: float | None,
+) -> tuple[int, int] | None:
+    if meta_group_id not in MANUFACTURABLE_META_GROUPS:
+        return None
+    if category_id not in ALLOWED_CATEGORIES:
+        return None
+    if group_name in EXCLUDED_GROUPS or type_name in EXCLUDED_NAMES:
+        return None
+
+    if meta_group_id == 1:
+        return (10, 10)
+
+    if meta_group_id == 2 and category_id in T2_MODULE_CATEGORIES:
+        if jita_price is not None and jita_price > HIGH_VALUE_THRESHOLD:
+            return (4, 5)
+        return (0, 10)
+
+    if meta_group_id == 2 and category_id == 6:
+        return (3, 3)
+
+    return (0, 1)
+
+
+def _get_meta_groups(type_ids: list[int], sde_engine: Engine) -> dict[int, int]:
+    if not type_ids:
+        return {}
+
+    placeholders = ", ".join(f":type_id_{index}" for index, _ in enumerate(type_ids))
+    params = {f"type_id_{index}": type_id for index, type_id in enumerate(type_ids)}
+    query = text(
+        f"SELECT typeID, metaGroupID FROM sdetypes WHERE typeID IN ({placeholders})"
+    )
+
+    with sde_engine.connect() as conn:
+        result = conn.execute(query, params)
+        meta_groups: dict[int, int] = {}
+        for row in result.mappings():
+            type_id = row.get("typeID")
+            meta_group_id = row.get("metaGroupID")
+            if type_id is None or meta_group_id is None:
+                continue
+            meta_groups[int(type_id)] = int(meta_group_id)
+        return meta_groups
+
+
+def _build_request_url(type_id: int, me: int, runs: int) -> str:
+    return (
+        f"{EVEREF_BASE_URL}?product_id={type_id}&runs={runs}&me={me}"
+        f"&te={DEFAULT_TE}&material_prices={DEFAULT_MATERIAL_PRICE_SOURCE}"
+        f"&{EVEREF_STATIC_PARAMS}"
+    )
+
+
+async def _fetch_one(
+    client: httpx.AsyncClient,
+    semaphore: asyncio.Semaphore,
+    limiter: AsyncLimiter,
+    type_id: int,
+    me: int,
+    runs: int,
+) -> BuilderCostRecord | None:
+    url = _build_request_url(type_id, me, runs)
+
+    async with limiter:
+        async with semaphore:
+            try:
+                response = await client.get(url, timeout=API_TIMEOUT)
+            except Exception as exc:
+                logger.warning(f"EverRef fetch failed for {type_id}: {exc}")
+                return None
+
+    if response.status_code != 200:
+        logger.warning(
+            f"EverRef returned HTTP {response.status_code} for {type_id}: {response.text[:200]}"
+        )
+        return None
+
+    try:
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise TypeError("payload is not a dictionary")
+        manufacturing = payload.get("manufacturing")
+        if not isinstance(manufacturing, dict):
+            raise KeyError("manufacturing")
+        result = manufacturing[str(type_id)]
+        if not isinstance(result, dict):
+            raise TypeError("manufacturing result is not a dictionary")
+    except (KeyError, TypeError, ValueError) as exc:
+        logger.warning(f"EverRef response missing manufacturing data for {type_id}: {exc}")
+        return None
+
+    total_cost = result.get("total_cost_per_unit")
+    if total_cost is None:
+        logger.warning(f"EverRef response missing total_cost_per_unit for {type_id}")
+        return None
+
+    return {
+        "type_id": type_id,
+        "total_cost_per_unit": float(total_cost),
+        "time_per_unit": _parse_iso_duration(result.get("time_per_unit")),
+        "me": me,
+        "runs": runs,
+        "fetched_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+async def async_fetch_builder_costs(
+    type_ids: list[int],
+    jita_prices: dict[int, float],
+    sde_engine: Engine,
+    watchlist_metadata: Mapping[int, WatchlistMetadata] | None = None,
+) -> list[BuilderCostRecord]:
+    watchlist_metadata = watchlist_metadata or {}
+    meta_groups = _get_meta_groups(type_ids, sde_engine)
+
+    fetch_jobs: list[tuple[int, int, int]] = []
+    for type_id in type_ids:
+        metadata = watchlist_metadata.get(type_id, {})
+        params = _resolve_api_params(
+            meta_group_id=meta_groups.get(type_id),
+            category_id=metadata.get("category_id") if metadata else None,
+            group_name=metadata.get("group_name") if metadata else None,
+            type_name=metadata.get("type_name") if metadata else None,
+            jita_price=jita_prices.get(type_id),
+        )
+        if params is None:
+            continue
+        me, runs = params
+        fetch_jobs.append((type_id, me, runs))
+
+    if not fetch_jobs:
+        logger.info("No manufacturable watchlist items matched the builder cost filters")
+        return []
+
+    semaphore = asyncio.Semaphore(MAX_CONCURRENCY)
+    limiter = AsyncLimiter(30, time_period=60.0)
+    headers = {"User-Agent": ESIConfig("primary").user_agent}
+
+    async with httpx.AsyncClient(http2=True, headers=headers) as client:
+        results = await asyncio.gather(
+            *(
+                _fetch_one(client, semaphore, limiter, type_id, me, runs)
+                for type_id, me, runs in fetch_jobs
+            )
+        )
+
+    successful = [result for result in results if result is not None]
+    logger.info(f"{len(successful)}/{len(fetch_jobs)} items fetched successfully")
+    if len(successful) != len(fetch_jobs):
+        logger.warning("Builder cost fetch incomplete; aborting write to avoid partial replacement")
+        return []
+    return successful
+
+
+def run_async_fetch_builder_costs(
+    type_ids: list[int],
+    jita_prices: dict[int, float],
+    sde_engine: Engine,
+    watchlist_metadata: Mapping[int, WatchlistMetadata] | None = None,
+) -> list[BuilderCostRecord]:
+    return asyncio.run(
+        async_fetch_builder_costs(
+            type_ids,
+            jita_prices,
+            sde_engine,
+            watchlist_metadata=watchlist_metadata,
+        )
+    )

--- a/src/mkts_backend/esi/esi_requests.py
+++ b/src/mkts_backend/esi/esi_requests.py
@@ -1,13 +1,16 @@
 import os
+from typing import Literal, TypedDict
+
+import json
+import time
+
+import pandas as pd
+import requests
+from millify import millify
 
 from mkts_backend.config.esi_config import ESIConfig
 from mkts_backend.config.logging_config import configure_logging
 from mkts_backend.config.settings_service import SettingsService
-import requests
-import time
-import json
-import pandas as pd
-import millify
 
 logger = configure_logging(__name__)
 
@@ -18,13 +21,38 @@ _USER_AGENT = SettingsService().esi_user_agent
 QUIET = os.environ.get("MKTS_QUIET", "0") == "1"
 
 
+class MarketOrderRow(TypedDict, total=False):
+    order_id: int
+    type_id: int
+    type_name: str
+    price: float
+    volume_remain: int
+    is_buy_order: bool
+    duration: int
+    issued: str
+
+
+class FetchMarketOrdersUnchanged(TypedDict):
+    status: Literal[304]
+
+
+class FetchMarketOrdersSuccess(TypedDict):
+    status: Literal[200]
+    data: list[MarketOrderRow]
+    page_etags: dict[int, str]
+    expires: str | None
+
+
+FetchMarketOrdersResult = FetchMarketOrdersSuccess | FetchMarketOrdersUnchanged
+
+
 def fetch_market_orders(
     esi: ESIConfig,
     order_type: str = "all",
     page_etags: dict[int, str] | None = None,
     test_mode: bool = False,
     _clean_retry: bool = False,
-) -> dict:
+) -> FetchMarketOrdersResult | None:
     """Fetch market orders with per-page etag support.
 
     Returns:
@@ -173,7 +201,7 @@ def fetch_market_orders(
     }
 
 
-def fetch_history(watchlist: pd.DataFrame) -> list[dict]:
+def fetch_history(watchlist: pd.DataFrame) -> list[dict[str, object]] | None:
     from mkts_backend.config.market_context import MarketContext
     esi = ESIConfig(market_context=MarketContext.from_settings("primary"))
     url = esi.market_history_url
@@ -192,10 +220,15 @@ def fetch_history(watchlist: pd.DataFrame) -> list[dict]:
     type_ids = watchlist["type_id"].tolist()
     logger.info(f"Fetching history for {len(type_ids)} types")
 
-    headers = esi.headers()
-    del headers["Authorization"]
+    headers = {
+        "Accept-Language": "en",
+        "X-Compatibility-Date": esi.compatibility_date,
+        "X-Tenant": "tranquility",
+        "Accept": "application/json",
+        "User-Agent": esi.user_agent,
+    }
 
-    history = []
+    history: list[dict[str, object]] = []
     request_count = 0
     watchlist_length = len(type_ids)
 
@@ -220,17 +253,24 @@ def fetch_history(watchlist: pd.DataFrame) -> list[dict]:
 
             if response.status_code == 200:
                 logger.info(f"response successful: {response.status_code}")
-                error_remain = int(response.headers.get("X-Esi-Error-Limit-Remain"))
+                error_remain_header = response.headers.get(
+                    "X-Esi-Error-Limit-Remain", "100"
+                )
+                error_remain = int(error_remain_header)
                 if error_remain < 100:
                     logger.info(f"error_remain: {error_remain}")
 
                 data = response.json()
-                for record in data:
-                    record["type_name"] = item_name
-                    record["type_id"] = type_id
-
                 if isinstance(data, list):
-                    history.extend(data)
+                    for record in data:
+                        if not isinstance(record, dict):
+                            logger.warning(
+                                f"Unexpected history record type for {item_name}: {type(record)!r}"
+                            )
+                            continue
+                        record["type_name"] = item_name
+                        record["type_id"] = type_id
+                        history.append(record)
                 else:
                     logger.warning(f"Unexpected data format for {item_name}")
             else:
@@ -262,7 +302,8 @@ def fetch_history(watchlist: pd.DataFrame) -> list[dict]:
                 )
     if history:
         logger.info(f"Successfully fetched {len(history)} total history records")
-        with open("data/market_history.json", "w") as f:
+        os.makedirs("data", exist_ok=True)
+        with open("data/market_history.json", "w", encoding="utf-8") as f:
             json.dump(history, f)
         return history
     else:
@@ -270,8 +311,8 @@ def fetch_history(watchlist: pd.DataFrame) -> list[dict]:
         return None
 
 
-def fetch_region_orders(region_id: int, order_type: str = "sell") -> list[dict]:
-    orders = []
+def fetch_region_orders(region_id: int, order_type: str = "sell") -> list[dict[str, object]]:
+    orders: list[dict[str, object]] = []
     max_pages = 1
     page = 1
     error_count = 0
@@ -279,7 +320,9 @@ def fetch_region_orders(region_id: int, order_type: str = "sell") -> list[dict]:
     begin_time = time.time()
 
     while page <= max_pages:
-        status_code = None
+        status_code: int | None = None
+        response: requests.Response | None = None
+        elapsed = "0"
 
         headers = {
             "User-Agent": _USER_AGENT,
@@ -329,6 +372,13 @@ def fetch_region_orders(region_id: int, order_type: str = "sell") -> list[dict]:
             continue
 
         if status_code == 200:
+            if response is None:
+                logger.error(f"page {page} of {max_pages} | request missing response object")
+                error_count += 1
+                if error_count > 5:
+                    raise Exception(f"Too many errors: {error_count}")
+                time.sleep(1)
+                continue
             error_remain = response.headers.get("X-Error-Limit-Remain")
             if error_remain == "0":
                 logger.critical(f"Too many errors: {error_count}")
@@ -340,7 +390,7 @@ def fetch_region_orders(region_id: int, order_type: str = "sell") -> list[dict]:
                 max_pages = 1
 
             try:
-                order_page = response.json()
+                raw_order_page = response.json()
             except requests.exceptions.JSONDecodeError:
                 logger.warning(
                     f"Malformed JSON on page {page} of {max_pages}, retrying once..."
@@ -350,9 +400,17 @@ def fetch_region_orders(region_id: int, order_type: str = "sell") -> list[dict]:
                 if response.status_code != 200:
                     error_count += 1
                     continue
-                order_page = response.json()
+                raw_order_page = response.json()
         else:
             continue
+
+        if not isinstance(raw_order_page, list):
+            logger.warning(
+                f"Unexpected orders page format for region {region_id}, page {page}"
+            )
+            order_page: list[dict[str, object]] = []
+        else:
+            order_page = [order for order in raw_order_page if isinstance(order, dict)]
 
         if order_page == []:
             logger.info("No more orders found")
@@ -370,7 +428,7 @@ def fetch_region_orders(region_id: int, order_type: str = "sell") -> list[dict]:
     return orders
 
 
-def fetch_region_item_history(region_id: int, type_id: int) -> list[dict]:
+def fetch_region_item_history(region_id: int, type_id: int) -> list[dict[str, object]]:
     url = f"https://esi.evetech.net/latest/markets/{region_id}/history"
     querystring = {"type_id": type_id}
 
@@ -386,7 +444,11 @@ def fetch_region_item_history(region_id: int, type_id: int) -> list[dict]:
     try:
         response = requests.get(url, headers=headers, params=querystring, timeout=10)
         if response.status_code == 200:
-            return response.json()
+            data = response.json()
+            if isinstance(data, list):
+                return [record for record in data if isinstance(record, dict)]
+            logger.error(f"Unexpected history response format for type_id {type_id}")
+            return []
         else:
             logger.error(f"HTTP {response.status_code} for type_id {type_id}")
             return []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -443,6 +443,20 @@ def in_memory_sde_db(tmp_path):
         """))
         conn.execute(sa_text("INSERT INTO invCategories VALUES (4,'Material')"))
 
+        # Mark 34 and 35 as buildable (productTypeID with activityID=1 = manufacturing).
+        # Fixture stand-ins for "items produced from a blueprint"; 36 is intentionally
+        # absent so tests can exercise the unbuildable-filter behavior in _get_meta_groups.
+        conn.execute(sa_text("""
+            CREATE TABLE industryActivityProducts (
+                typeID INTEGER,
+                activityID INTEGER,
+                productTypeID INTEGER,
+                quantity INTEGER
+            )
+        """))
+        conn.execute(sa_text("INSERT INTO industryActivityProducts VALUES (1001, 1, 34, 100)"))
+        conn.execute(sa_text("INSERT INTO industryActivityProducts VALUES (1002, 1, 35, 100)"))
+
         conn.commit()
     yield db_path
     engine.dispose()

--- a/tests/test_async_everref.py
+++ b/tests/test_async_everref.py
@@ -64,6 +64,23 @@ class TestGetMetaGroups:
 
         assert result == {34: 1, 35: 1}
 
+    def test_filters_out_items_with_no_manufacturing_blueprint(self, in_memory_sde_db):
+        """type_id 36 (Mexallon) exists in sdetypes but has no industryActivityProducts row.
+
+        Mirrors EverRef HTTP 400 "not produced from a blueprint" for meta-T1 NPC
+        drops; filtering at the SDE saves wasted rate-limited requests.
+        """
+        from mkts_backend.esi.async_everref import _get_meta_groups
+
+        engine = create_engine(f"sqlite:///{in_memory_sde_db}")
+        try:
+            result = _get_meta_groups([34, 35, 36], engine)
+        finally:
+            engine.dispose()
+
+        assert 36 not in result
+        assert result == {34: 1, 35: 1}
+
 
 class TestAsyncFetchBuilderCosts:
     @pytest.mark.asyncio

--- a/tests/test_async_everref.py
+++ b/tests/test_async_everref.py
@@ -1,0 +1,111 @@
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+
+
+class TestResolveApiParams:
+    def test_t1_items_use_default_me_and_runs(self):
+        from mkts_backend.esi.async_everref import _resolve_api_params
+
+        result = _resolve_api_params(
+            meta_group_id=1,
+            category_id=7,
+            group_name="Shield Extender",
+            type_name="Large Shield Extender I",
+            jita_price=1_500_000,
+        )
+
+        assert result == (10, 10)
+
+    def test_high_value_t2_modules_use_conservative_run_count(self):
+        from mkts_backend.esi.async_everref import _resolve_api_params
+
+        result = _resolve_api_params(
+            meta_group_id=2,
+            category_id=7,
+            group_name="Shield Extender",
+            type_name="Large Shield Extender II",
+            jita_price=45_000_000,
+        )
+
+        assert result == (4, 5)
+
+    def test_non_manufacturable_and_excluded_items_are_skipped(self):
+        from mkts_backend.esi.async_everref import _resolve_api_params
+
+        assert _resolve_api_params(5, 7, "Shield Extender", "Large Shield Extender II", 10) is None
+        assert _resolve_api_params(2, 7, "Interdiction Nullifier", "Interdiction Nullifier II", 10) is None
+        assert _resolve_api_params(14, 6, "Cruiser", "Vedmak", 10) is None
+
+
+class TestParseIsoDuration:
+    def test_parses_iso_duration_to_seconds(self):
+        from mkts_backend.esi.async_everref import _parse_iso_duration
+
+        assert _parse_iso_duration("PT24H20M48.1S") == 87648.1
+
+    def test_invalid_duration_returns_none(self):
+        from mkts_backend.esi.async_everref import _parse_iso_duration
+
+        assert _parse_iso_duration("not-a-duration") is None
+
+
+class TestGetMetaGroups:
+    def test_reads_meta_groups_from_sdetypes(self, in_memory_sde_db):
+        from mkts_backend.esi.async_everref import _get_meta_groups
+
+        engine = create_engine(f"sqlite:///{in_memory_sde_db}")
+        try:
+            result = _get_meta_groups([34, 35, 999999], engine)
+        finally:
+            engine.dispose()
+
+        assert result == {34: 1, 35: 1}
+
+
+class TestAsyncFetchBuilderCosts:
+    @pytest.mark.asyncio
+    async def test_partial_failures_abort_the_batch(self, in_memory_sde_db):
+        from mkts_backend.esi import async_everref
+
+        engine = create_engine(f"sqlite:///{in_memory_sde_db}")
+        watchlist_metadata = {
+            34: {
+                "category_id": 7,
+                "group_name": "Shield Extender",
+                "type_name": "Large Shield Extender I",
+            },
+            35: {
+                "category_id": 7,
+                "group_name": "Shield Extender",
+                "type_name": "Large Shield Extender I",
+            },
+        }
+
+        with patch.object(
+            async_everref,
+            "_fetch_one",
+            side_effect=[
+                {
+                    "type_id": 34,
+                    "total_cost_per_unit": 123.4,
+                    "time_per_unit": 60.0,
+                    "me": 10,
+                    "runs": 10,
+                    "fetched_at": "2026-04-17T00:00:00+00:00",
+                },
+                None,
+            ],
+        ):
+            try:
+                results = await async_everref.async_fetch_builder_costs(
+                    [34, 35],
+                    {34: 1_000_000, 35: 1_000_000},
+                    engine,
+                    watchlist_metadata=watchlist_metadata,
+                )
+            finally:
+                engine.dispose()
+
+        assert results == []

--- a/tests/test_async_everref.py
+++ b/tests/test_async_everref.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import pytest
@@ -93,7 +94,7 @@ class TestAsyncFetchBuilderCosts:
                     "time_per_unit": 60.0,
                     "me": 10,
                     "runs": 10,
-                    "fetched_at": "2026-04-17T00:00:00+00:00",
+                    "fetched_at": datetime(2026, 4, 17, tzinfo=timezone.utc),
                 },
                 None,
             ],

--- a/tests/test_builder_cost_pipeline.py
+++ b/tests/test_builder_cost_pipeline.py
@@ -1,0 +1,230 @@
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+
+def _make_db_mock(watchlist_df: pd.DataFrame | None = None) -> MagicMock:
+    db = MagicMock()
+    engine = MagicMock()
+    conn = MagicMock()
+    context_manager = MagicMock()
+    context_manager.__enter__.return_value = conn
+    context_manager.__exit__.return_value = False
+    engine.connect.return_value = context_manager
+    db.engine = engine
+    db.verify_db_exists.return_value = True
+    db.get_watchlist.return_value = watchlist_df if watchlist_df is not None else pd.DataFrame()
+    return db
+
+
+class TestProcessBuilderCosts:
+    @patch("pandas.read_sql_query")
+    @patch("mkts_backend.esi.async_everref.run_async_fetch_builder_costs")
+    @patch("mkts_backend.cli.DatabaseConfig")
+    def test_returns_false_when_any_market_prep_fails(
+        self,
+        mock_db_config,
+        mock_fetch,
+        mock_read_sql_query,
+        primary_market_context,
+        deployment_market_context,
+    ):
+        from mkts_backend.cli import process_builder_costs
+
+        prep_primary = _make_db_mock()
+        prep_deployment = _make_db_mock()
+        prep_deployment.sync.side_effect = RuntimeError("sync failed")
+        watch_primary = _make_db_mock(
+            pd.DataFrame(
+                [
+                    {
+                        "type_id": 100,
+                        "type_name": "Large Shield Extender I",
+                        "group_name": "Shield Extender",
+                        "category_id": 7,
+                    }
+                ]
+            )
+        )
+        jita_primary = _make_db_mock()
+        sde_db = _make_db_mock()
+
+        mock_db_config.side_effect = [
+            prep_primary,
+            prep_deployment,
+            watch_primary,
+            jita_primary,
+            sde_db,
+        ]
+        mock_fetch.return_value = [
+            {
+                "type_id": 100,
+                "total_cost_per_unit": 123.4,
+                "time_per_unit": 60.0,
+                "me": 4,
+                "runs": 5,
+                "fetched_at": "2026-04-17T00:00:00+00:00",
+            }
+        ]
+        mock_read_sql_query.return_value = pd.DataFrame(
+            [{"type_id": 100, "sell_price": 50_000_000.0}]
+        )
+
+        result = process_builder_costs(
+            market_contexts=[primary_market_context, deployment_market_context]
+        )
+
+        assert result is False
+        mock_fetch.assert_not_called()
+
+    @patch("mkts_backend.cli.log_update")
+    @patch("mkts_backend.cli.upsert_database", return_value=True)
+    @patch("mkts_backend.cli._ensure_builder_costs_table")
+    @patch("mkts_backend.esi.async_everref.run_async_fetch_builder_costs")
+    @patch("pandas.read_sql_query")
+    @patch("mkts_backend.cli.DatabaseConfig")
+    def test_syncs_market_dbs_and_uses_first_nonempty_jita_table(
+        self,
+        mock_db_config,
+        mock_read_sql_query,
+        mock_fetch,
+        mock_ensure_table,
+        mock_upsert,
+        mock_log_update,
+        primary_market_context,
+        deployment_market_context,
+    ):
+        from mkts_backend.cli import process_builder_costs
+
+        watchlist_df = pd.DataFrame(
+            [
+                {
+                    "type_id": 100,
+                    "type_name": "Large Shield Extender I",
+                    "group_name": "Shield Extender",
+                    "category_id": 7,
+                }
+            ]
+        )
+
+        prep_primary = _make_db_mock()
+        prep_deployment = _make_db_mock()
+        watch_primary = _make_db_mock(watchlist_df)
+        watch_deployment = _make_db_mock(pd.DataFrame())
+        jita_primary = _make_db_mock()
+        jita_deployment = _make_db_mock()
+        sde_db = _make_db_mock()
+
+        mock_db_config.side_effect = [
+            prep_primary,
+            prep_deployment,
+            watch_primary,
+            watch_deployment,
+            jita_primary,
+            jita_deployment,
+            sde_db,
+        ]
+        mock_read_sql_query.side_effect = [
+            pd.DataFrame(columns=["type_id", "sell_price"]),
+            pd.DataFrame([{"type_id": 100, "sell_price": 50_000_000.0}]),
+        ]
+        mock_fetch.return_value = [
+            {
+                "type_id": 100,
+                "total_cost_per_unit": 123.4,
+                "time_per_unit": 60.0,
+                "me": 4,
+                "runs": 5,
+                "fetched_at": "2026-04-17T00:00:00+00:00",
+            }
+        ]
+
+        result = process_builder_costs(
+            market_contexts=[primary_market_context, deployment_market_context]
+        )
+
+        assert result is True
+        prep_primary.sync.assert_called_once_with()
+        prep_deployment.sync.assert_called_once_with()
+        assert mock_read_sql_query.call_count == 2
+        fetch_args, fetch_kwargs = mock_fetch.call_args
+        assert fetch_args[1] == {100: 50_000_000.0}
+        assert fetch_kwargs["watchlist_metadata"] == {
+            100: {
+                "type_id": 100,
+                "type_name": "Large Shield Extender I",
+                "group_name": "Shield Extender",
+                "category_id": 7,
+            }
+        }
+        assert mock_ensure_table.call_count == 2
+        assert mock_upsert.call_count == 2
+        assert mock_log_update.call_count == 2
+
+    @patch("mkts_backend.cli.log_update")
+    @patch("mkts_backend.cli._ensure_builder_costs_table")
+    @patch("mkts_backend.esi.async_everref.run_async_fetch_builder_costs")
+    @patch("pandas.read_sql_query")
+    @patch("mkts_backend.cli.DatabaseConfig")
+    @patch("mkts_backend.cli.upsert_database")
+    def test_returns_false_if_any_market_write_fails(
+        self,
+        mock_upsert,
+        mock_db_config,
+        mock_read_sql_query,
+        mock_fetch,
+        mock_ensure_table,
+        mock_log_update,
+        primary_market_context,
+        deployment_market_context,
+    ):
+        from mkts_backend.cli import process_builder_costs
+
+        watchlist_df = pd.DataFrame(
+            [
+                {
+                    "type_id": 100,
+                    "type_name": "Large Shield Extender I",
+                    "group_name": "Shield Extender",
+                    "category_id": 7,
+                }
+            ]
+        )
+
+        prep_primary = _make_db_mock()
+        prep_deployment = _make_db_mock()
+        watch_primary = _make_db_mock(watchlist_df)
+        watch_deployment = _make_db_mock(pd.DataFrame())
+        jita_primary = _make_db_mock()
+        sde_db = _make_db_mock()
+
+        mock_db_config.side_effect = [
+            prep_primary,
+            prep_deployment,
+            watch_primary,
+            watch_deployment,
+            jita_primary,
+            sde_db,
+        ]
+        mock_read_sql_query.return_value = pd.DataFrame(
+            [{"type_id": 100, "sell_price": 50_000_000.0}]
+        )
+        mock_fetch.return_value = [
+            {
+                "type_id": 100,
+                "total_cost_per_unit": 123.4,
+                "time_per_unit": 60.0,
+                "me": 4,
+                "runs": 5,
+                "fetched_at": "2026-04-17T00:00:00+00:00",
+            }
+        ]
+        mock_upsert.side_effect = [True, False]
+
+        result = process_builder_costs(
+            market_contexts=[primary_market_context, deployment_market_context]
+        )
+
+        assert result is False
+        assert mock_upsert.call_count == 2
+        assert mock_log_update.call_count == 1

--- a/tests/test_builder_cost_pipeline.py
+++ b/tests/test_builder_cost_pipeline.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
@@ -63,7 +64,7 @@ class TestProcessBuilderCosts:
                 "time_per_unit": 60.0,
                 "me": 4,
                 "runs": 5,
-                "fetched_at": "2026-04-17T00:00:00+00:00",
+                "fetched_at": datetime(2026, 4, 17, tzinfo=timezone.utc),
             }
         ]
         mock_read_sql_query.return_value = pd.DataFrame(
@@ -135,7 +136,7 @@ class TestProcessBuilderCosts:
                 "time_per_unit": 60.0,
                 "me": 4,
                 "runs": 5,
-                "fetched_at": "2026-04-17T00:00:00+00:00",
+                "fetched_at": datetime(2026, 4, 17, tzinfo=timezone.utc),
             }
         ]
 
@@ -216,7 +217,7 @@ class TestProcessBuilderCosts:
                 "time_per_unit": 60.0,
                 "me": 4,
                 "runs": 5,
-                "fetched_at": "2026-04-17T00:00:00+00:00",
+                "fetched_at": datetime(2026, 4, 17, tzinfo=timezone.utc),
             }
         ]
         mock_upsert.side_effect = [True, False]

--- a/tests/test_cli_routing.py
+++ b/tests/test_cli_routing.py
@@ -127,6 +127,41 @@ class TestArgsParserRouting:
         _, kwargs = mock_run.call_args
         assert kwargs["market_alias"] == "primary"
 
+    @patch("mkts_backend.cli.process_builder_costs", return_value=True)
+    @patch("mkts_backend.cli.init_databases")
+    @patch("mkts_backend.config.market_context.MarketContext.from_settings")
+    @patch("mkts_backend.config.market_context.MarketContext.list_available")
+    def test_update_builder_costs_routes(
+        self,
+        mock_list_available,
+        mock_from_settings,
+        mock_init_dbs,
+        mock_process,
+    ):
+        from mkts_backend.cli_tools.args_parser import parse_args
+
+        primary_ctx = MagicMock(alias="primary")
+        deployment_ctx = MagicMock(alias="deployment")
+        mock_list_available.return_value = ["primary", "deployment"]
+        mock_from_settings.side_effect = [primary_ctx, deployment_ctx]
+
+        with pytest.raises(SystemExit) as exc_info:
+            parse_args(["update-builder-costs"])
+
+        assert exc_info.value.code == 0
+        mock_init_dbs.assert_called_once_with()
+        mock_process.assert_called_once_with(market_contexts=[primary_ctx, deployment_ctx])
+
+    def test_update_builder_costs_help_reaches_subcommand_help(self, capsys):
+        from mkts_backend.cli_tools.args_parser import parse_args
+
+        with pytest.raises(SystemExit) as exc_info:
+            parse_args(["update-builder-costs", "--help"])
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert "update-builder-costs: Fetch EverRef manufacturing costs" in captured.out
+
     @patch(
         "mkts_backend.cli_tools.asset_check.asset_check_command", return_value=True
     )

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -69,6 +69,7 @@ class TestGlobalRegistry:
         expected = {
             "fit-check", "fit-update", "update-fit", "update-target",
             "assets", "equiv", "sync", "validate", "parse-items",
+            "update-builder-costs",
             "esi-auth", "add_watchlist", "list-fits", "needed", "module",
         }
         registered = {e.name for e in reg.all_commands()}
@@ -82,6 +83,8 @@ class TestGlobalRegistry:
         assert reg.resolve("lf").name == "list-fits"
         assert reg.resolve("add-watchlist") is not None
         assert reg.resolve("add-watchlist").name == "add_watchlist"
+        assert reg.resolve("builder-costs") is not None
+        assert reg.resolve("builder-costs").name == "update-builder-costs"
 
     def test_all_commands_have_handler_and_description(self):
         reg = get_registry()

--- a/tests/test_esi_fetch.py
+++ b/tests/test_esi_fetch.py
@@ -182,7 +182,7 @@ class TestFetchHistory:
         with patch("mkts_backend.esi.esi_requests.ESIConfig") as MockESI:
             mock_esi = MagicMock()
             mock_esi.market_history_url = "https://esi.evetech.net/markets/10000003/history"
-            mock_esi.headers.return_value = {"Accept": "application/json", "Authorization": "Bearer test"}
+            mock_esi.headers = {"Accept": "application/json", "Authorization": "Bearer test"}
             MockESI.return_value = mock_esi
 
             with patch("mkts_backend.esi.esi_requests.requests.get", return_value=resp):
@@ -194,4 +194,63 @@ class TestFetchHistory:
         assert len(result) == 2
         # Each record should have type_name and type_id injected
         assert result[0]["type_name"] == "Tritanium"
+        assert result[0]["type_id"] == 34
+
+    def test_basic_fetch_creates_data_directory(self, tmp_path, monkeypatch):
+        """Successful history fetch should create data/ before writing market_history.json."""
+        watchlist = pd.DataFrame({
+            "type_id": [34],
+            "type_name": ["Tritanium"],
+        })
+        history_data = [
+            {"date": "2026-02-10", "average": 8.5, "volume": 2000},
+        ]
+        resp = _make_response(
+            json_data=history_data,
+            headers={"X-Esi-Error-Limit-Remain": "100"},
+        )
+
+        monkeypatch.chdir(tmp_path)
+
+        with patch("mkts_backend.esi.esi_requests.ESIConfig") as MockESI:
+            mock_esi = MagicMock()
+            mock_esi.market_history_url = "https://esi.evetech.net/markets/10000003/history"
+            mock_esi.headers = {"Accept": "application/json", "Authorization": "Bearer test"}
+            MockESI.return_value = mock_esi
+
+            with patch("mkts_backend.esi.esi_requests.requests.get", return_value=resp):
+                with patch("mkts_backend.esi.esi_requests.time.sleep"):
+                    from mkts_backend.esi.esi_requests import fetch_history
+                    result = fetch_history(watchlist)
+
+        assert result is not None
+        assert (tmp_path / "data" / "market_history.json").exists()
+
+    def test_basic_fetch_does_not_require_authenticated_headers(self):
+        """Public history fetch should use public headers and not touch the authenticated headers property."""
+        watchlist = pd.DataFrame({
+            "type_id": [34],
+            "type_name": ["Tritanium"],
+        })
+        resp = _make_response(
+            json_data=[{"date": "2026-02-10", "average": 8.5, "volume": 2000}],
+            headers={"X-Esi-Error-Limit-Remain": "100"},
+        )
+
+        class StubESI:
+            market_history_url = "https://esi.evetech.net/markets/10000003/history"
+            user_agent = "test-agent"
+            compatibility_date = "2020-01-01"
+
+            @property
+            def headers(self):
+                raise AssertionError("authenticated headers should not be used")
+
+        with patch("mkts_backend.esi.esi_requests.ESIConfig", return_value=StubESI()):
+            with patch("mkts_backend.esi.esi_requests.requests.get", return_value=resp):
+                with patch("mkts_backend.esi.esi_requests.time.sleep"):
+                    from mkts_backend.esi.esi_requests import fetch_history
+                    result = fetch_history(watchlist)
+
+        assert result is not None
         assert result[0]["type_id"] == 34

--- a/tests/test_settings_service.py
+++ b/tests/test_settings_service.py
@@ -25,7 +25,7 @@ def test_settings_loads_and_exposes_typed_properties():
     assert s.environment in {"production", "development"}
     assert s.log_level in {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
     assert s.esi_user_agent.startswith("wcmkts_backend/")
-    assert s.wipe_replace_tables == ["marketstats", "doctrines", "jita_prices"]
+    assert s.wipe_replace_tables == ["marketstats", "doctrines", "jita_prices", "builder_costs"]
 
 
 def test_cache_is_shared_across_instances():


### PR DESCRIPTION
Adds a new update-builder-costs pipeline for fetching Everef manufacturing cost estimates for manufacturable watchlist items and writing them into each configured market database.

This branch includes:

a new async Everef fetcher and builder-cost processing flow
a builder_costs database model and persistence logic
CLI routing plus aliases for update-builder-costs, builder-costs, and ubc
a scheduled GitHub Actions workflow for regular collection
docs and tests covering the new pipeline end to end