### PR TITLE
fit-update: batch DB connections, close provisioning gaps, fix update-lead-ship

### DIFF
--- a/docs/fit_update_simplification_followup.md
+++ b/docs/fit_update_simplification_followup.md
@@ -1,0 +1,180 @@
+# Follow-up: `fit_update.py` Simplification
+
+## Status
+
+**Deferred** from the April 2026 CLI-tool fixes PR. That PR landed the
+correctness + batching fixes described in `cli-tool-fixes.md` but did not
+achieve the broader simplification the plan gestured at
+(`~3,051 → ~2,400 lines`). Current size: **3,301 lines** across 13
+subcommands. This memo captures what's left.
+
+## Why it was deferred
+
+The original `cli-tool-fixes.md` plan had four concrete bug fixes and a
+generic "the code is incredibly verbose" hunch. The PR tackled the four
+bugs (DB batching, ship_targets gap, lead_ship gap, `update-lead-ship`
+market handling) plus a shared `_provision_fit_in_market` helper. The
+*further* deduplication below would have:
+
+- Mixed correctness work with pure cleanup in one PR.
+- Expanded the blast radius for review and staging verification.
+- Required touching `interactive_add_fit` (currently 318 lines of its own
+  interactive flow) which has no reported bugs.
+
+Shipping them separately lets each land on its own merits.
+
+## What's left to simplify
+
+### 1. Third "add a fit" code path still duplicates the provisioning sequence
+
+`interactive_add_fit` (lines 282–598 in `fit_update.py`) adds a new fit
+from an EFT file. It calls `update_fit_workflow` (in
+`utils/parse_fits.py`) per target market DB, which internally does its
+own `upsert_doctrine_fits` / `upsert_doctrine_map` / `upsert_ship_target`
+/ `refresh_doctrines_for_fit` sequence — parallel to
+`_provision_fit_in_market` but not reusing it.
+
+Why fixing this is non-trivial:
+
+- `update_fit_workflow` also writes into `fittings_fittingitem` / `fittings_fitting` (the fittings DB, not market DB), which `_provision_fit_in_market` does not do.
+- The fittings-DB writes are the *identity-establishing* step: `_provision_fit_in_market` assumes the fit already exists in fittings and only updates per-market tables. For `add`, the fit is being created.
+
+Proposed split:
+
+- `parse_fits.register_fit_in_fittings_db(fit_id, parse_result)` — owns
+  fittings-DB writes only.
+- `_provision_fit_in_market(conn, p, market_flag)` — owns market-DB
+  writes only (already exists).
+- `interactive_add_fit` composes: parse EFT → register in fittings →
+  bucket per-market provision (same pattern as
+  `doctrine_add_fit_command` post-refactor).
+
+Payoff: one canonical "fit gets into market DB" code path, used by
+`add`, `assign-market`, `doctrine-add-fit`. Lead-ship + ship-target
+provisioning would be guaranteed identical across all three.
+
+Estimated reduction: ~150 lines in `interactive_add_fit` + ~80 in
+`update_fit_workflow`.
+
+### 2. Legacy wrappers kept for backwards compatibility
+
+The PR kept two thin wrappers so no unaudited caller breaks:
+
+- `_provision_market_db(p, alias, new_flag, remote)` →
+  `_prepare_watchlist_for_fit` + `engine.begin()` +
+  `_provision_fit_in_market`. Lines 1104–1124.
+- `_cleanup_market_db(fit_id, doctrine_id, alias, remote)` →
+  `engine.begin()` + `_cleanup_fit_in_market`. Lines 1148–1162.
+
+Grep shows they are called only from the old non-batched paths
+(`_execute_market_plan` does not use them anymore). Removing them is
+safe once a full caller audit confirms nothing outside
+`fit_update.py` imports them.
+
+Payoff: ~40 lines removed + clearer "one way to do it" semantics.
+
+### 3. Hard-coded `("wcmktprod", "wcmktnorth")` in fallback searches
+
+Six call sites still iterate the tuple directly, all in
+`fit_update.py`:
+
+```
+line  637  for fallback in ("wcmktprod", "wcmktnorth"):       # assign-market fallback lookup
+line  714  for fallback in ("wcmktprod", "wcmktnorth"):       # assign-doctrine-market fallback lookup
+line  897  for target in ("wcmktprod", "wcmktnorth"):         # _get_remote_market_flags
+line 1381  for fallback in ("wcmktprod", "wcmktnorth"):       # unassign fallback lookup
+line 1453  for fallback in ("wcmktprod", "wcmktnorth"):       # unassign-doctrine fallback lookup
+line 2754  for target in ("wcmkt", "wcmktnorth"):             # (unclear context, verify before change)
+line 2784  for target in ("wcmkt", "wcmktnorth"):             # (unclear context, verify before change)
+```
+
+These are "search for a fit across known remote DBs" loops. Replacing
+the tuples with `_configured_market_db_aliases()` makes them
+config-driven. The catch: a few of them pair the tuple with a specific
+semantic ("try remote wcmktprod first, then wcmktnorth") where ordering
+matters for the user-visible result. Audit the intent before each
+replacement.
+
+Payoff: ~30 lines saved, plus automatic support for future markets.
+
+### 4. `_FLAG_ALIAS_MAP` encodes market semantics inline
+
+`_flag_to_aliases` (lines 753–762) hard-codes:
+
+```python
+_FLAG_ALIAS_MAP = {
+    "primary":    {"wcmktprod"},
+    "deployment": {"wcmktnorth"},
+    "both":       {"wcmktprod", "wcmktnorth"},
+}
+```
+
+This is functionally a specialized case of
+`_configured_market_db_aliases(market_flag)` returning a `set` instead
+of a `list`. Unifying them:
+
+```python
+def _flag_to_aliases(flag: str) -> set[str]:
+    return set(_configured_market_db_aliases(flag))
+```
+
+Single source of truth for flag → DB resolution. Will also automatically
+pick up any new markets added to `settings.toml`.
+
+Payoff: ~10 lines. Mostly a clarity win.
+
+### 5. `fit_update.py` decomposition into per-subcommand modules
+
+The file currently holds 13 subcommand handlers plus ~15 shared helpers
+in 3,301 lines. Natural decomposition:
+
+```
+src/mkts_backend/cli_tools/fit_update/
+├── __init__.py            # re-exports fit_update_command (dispatcher)
+├── _shared.py             # _configured_market_db_aliases, _flag_to_aliases,
+│                          # _get_doctrine_fits_rows, _apply_step,
+│                          # _provision_fit_in_market, _cleanup_fit_in_market,
+│                          # _prepare_watchlist_for_fit, _execute_market_plan,
+│                          # _plan_market_action, _display_market_preview
+├── add.py                 # interactive_add_fit
+├── assign.py              # assign_market_command, assign_doctrine_market
+├── unassign.py            # unassign_market_command, unassign_doctrine_market
+├── doctrine.py            # create_doctrine_command, doctrine_add_fit_command,
+│                          # doctrine_remove_fit_command
+├── remove.py              # remove_fit_command
+├── update_target.py       # update_target_command
+├── lead_ship.py           # update_lead_ship_command
+├── friendly_name.py       # update_friendly_name_command,
+│                          # populate_friendly_names_command
+└── list.py                # list_fits_command, list_doctrines_command
+```
+
+The dispatcher (`fit_update_command`) then becomes a thin ~50-line
+router that imports lazily (same pattern the `CommandRegistry` already
+uses).
+
+Payoff: the pieces become independently reviewable and each file stays
+under ~400 lines. Not a functional change — purely organizational.
+
+This is the biggest item on the list and the one most likely to cause
+merge conflicts with in-flight work. Do it in a standalone PR with no
+logic changes.
+
+## Suggested order
+
+1. **#4 `_flag_to_aliases`** — tiny, safe, easy to verify. Warm-up.
+2. **#3 fallback-tuple replacement** — per-site audit, low risk.
+3. **#2 legacy wrapper removal** — grep confirms zero external callers,
+   then delete.
+4. **#1 `interactive_add_fit` dedup** — the real simplification win;
+   moves ~230 lines through two helper extractions.
+5. **#5 file decomposition** — last, once the content has stabilized.
+
+Doing #5 first would make #1–#4 harder to review because each change
+would span multiple new files. Save it for the end.
+
+## Related
+
+- `market_db_map_deferred.md` — the `MARKET_DB_MAP["primary"] = "wcmkt"`
+  follow-up. Pairs naturally with #3 and #4 here since they all touch
+  the market-alias resolution layer.

--- a/docs/market_db_map_deferred.md
+++ b/docs/market_db_map_deferred.md
@@ -1,0 +1,107 @@
+# Deferred Fix: `MARKET_DB_MAP["primary"] = "wcmkt"`
+
+## Status
+
+**Deferred.** Partially mitigated by the `fit-update` refactor (April 2026) that
+removed the visible `db_alias="wcmkt"` defaults in the CLI layer. The root
+mapping is still unchanged.
+
+## Issue
+
+`src/mkts_backend/cli_tools/market_args.py` currently defines:
+
+```python
+MARKET_DB_MAP: dict[str, str] = {
+    "primary": "wcmkt",      # <-- deprecated alias
+    "deployment": "wcmktnorth",
+}
+```
+
+`"wcmkt"` is deprecated — the real primary-market DB alias is `"wcmktprod"`.
+The code path works today only because `DatabaseConfig.__init__` normalizes
+`"wcmkt"` to `_production_db_alias` (which is `"wcmktprod"` per `settings.toml`),
+so every caller that passes `"wcmkt"` ends up on `wcmktprod` without errors.
+
+Why this matters:
+
+- The mapping leaks `"wcmkt"` to every caller that does
+  `MARKET_DB_MAP.get(market_alias, …)`.
+- New code grepping for "what DB alias does `primary` mean?" gets the wrong
+  answer (`wcmkt`) even though the runtime value is `wcmktprod`.
+- Any future tightening of `DatabaseConfig` that drops the
+  `wcmkt → wcmktprod` normalization will break callers silently.
+
+## What this PR did (partial mitigation)
+
+- Dropped the `db_alias="wcmkt"` default from
+  `update_lead_ship_command` — it now resolves DB aliases from `market_flag`
+  via `_configured_market_db_aliases`, which reads DB aliases directly from
+  `MarketContext.from_settings(market).database_alias` (i.e. from
+  `settings.toml`, not `MARKET_DB_MAP`).
+- Dropped the hard-coded `"wcmkt"` fallback in
+  `command_registry._handle_fit_update`. When the user's `--market` covers
+  multiple DBs (e.g. `both`), the handler now prompts interactively rather
+  than silently defaulting.
+- Replaced every hard-coded `["wcmkt", "wcmktnorth"]` and
+  `("wcmktprod", "wcmktnorth")` tuple inside `_execute_market_plan` and
+  `doctrine_add_fit_command` with `_configured_market_db_aliases()`, which
+  is config-driven and already returns the correct aliases.
+
+These changes make the system tolerant of the mapping being wrong but do
+not fix the mapping itself. `MARKET_DB_MAP["primary"]` still returns
+`"wcmkt"`, and several legacy call sites (listed below) still depend on
+the `DatabaseConfig` normalization.
+
+## What the full fix looks like
+
+1. **Change the mapping** in `src/mkts_backend/cli_tools/market_args.py`:
+
+   ```python
+   MARKET_DB_MAP: dict[str, str] = {
+       "primary": "wcmktprod",
+       "deployment": "wcmktnorth",
+   }
+   ```
+
+2. **Audit remaining `"wcmkt"` string literals** in the codebase. Current
+   hits (as of this PR) that still assume the deprecated alias:
+
+   ```
+   src/mkts_backend/cli_tools/fit_update.py       — multiple `db_alias="wcmkt"` defaults on
+                                                     helper functions that still exist
+                                                     (remove_fit_command, update_target_command,
+                                                     doctrine_remove_fit_command, etc.)
+   src/mkts_backend/utils/doctrine_update.py      — every helper defaults to `db_alias="wcmkt"`
+   src/mkts_backend/utils/db_utils.py             — `add_missing_items_to_watchlist(…, db_alias="wcmkt")`
+   ```
+
+   Most of these are fine for now (the `DatabaseConfig` normalization handles
+   it), but the defaults should be changed to `"wcmktprod"` for clarity.
+
+3. **Remove the `DatabaseConfig` normalization** once step 2 lands. The
+   normalization is at roughly `config/config.py:~101`, aliasing `"wcmkt"`
+   to `_production_db_alias`. It's a safety net for legacy callers; once
+   those callers are gone, the net should come down to prevent new callers
+   from latching onto the deprecated name.
+
+4. **Verify with `grep -rn '"wcmkt"' src/`**: should return zero hits.
+   Any remaining hit is either a config key (allowed) or a bug (must fix).
+
+## Why this was deferred
+
+Touching every call site risks incorrect behavior where a function that
+currently accepts `db_alias="wcmkt"` and internally normalizes to
+`wcmktprod` suddenly takes `"wcmktprod"` literally — which should be a
+no-op, but is a broad blast radius to verify in one PR. Keeping the fix
+scoped to the `fit-update` refactor avoided mixing concerns.
+
+## Pointers for the follow-up
+
+- Start with `grep -rn '"wcmkt"\b' src/` to find every literal.
+- Change defaults (`db_alias="wcmkt"` → `db_alias="wcmktprod"`) in
+  `doctrine_update.py` first — it's the most-called utility module.
+- Then flip `MARKET_DB_MAP["primary"]` and run the full test suite.
+- Finally remove the normalization in `DatabaseConfig`.
+- Smoke test: `mkts-backend fit-update list-fits --market=primary` must
+  hit `wcmktprod.db` locally and `wcmktprod_turso` remotely — same as
+  pre-change. Same for `--market=deployment` hitting `wcmktnorth`.

--- a/lead-ship-updates.md
+++ b/lead-ship-updates.md
@@ -1,11 +1,12 @@
 WCMKTnorth2
-DOCTRINE ID     DOCTRINE NAME            FRIENDLY NAME
-99              Special Fits             Special Fits
-100             cynos                    Cynos
-95              SUBS - WC Maelstroms     Maelstroms
-98              SUBS - WC-EN Muninn      Muninn
-97              SUBS - WC-EN Ferox       Ferox
-SELECT doctrine_id, fit_id, ship_name FROM doctrine_fits WHERE doctrine_id in (99,100,95,98,97);
+99 -> 991 both 
+100 -> 158 both
+95 -> 550 deployment
+98 -> 554 deployment
+97 -> 553 deployment
+44 -> 288 primary
+
+
 
 ┌─────────────┬────────┬────────────┐
 │ doctrine_id │ fit_id │ ship_name  │

--- a/src/mkts_backend/cli_tools/command_registry.py
+++ b/src/mkts_backend/cli_tools/command_registry.py
@@ -159,6 +159,7 @@ def _register_all(reg: CommandRegistry) -> None:
 
     # ── fit-update ──────────────────────────────────────────────
     def _handle_fit_update(args: list[str], market_alias: str) -> bool:
+        import sys
         from mkts_backend.cli_tools.arg_utils import ParsedArgs, ArgError
         from mkts_backend.cli_tools.market_args import (
             MARKET_DB_MAP,
@@ -166,6 +167,9 @@ def _register_all(reg: CommandRegistry) -> None:
             resolve_market_alias_interactive,
         )
         from mkts_backend.cli_tools.fit_update import fit_update_command
+        from mkts_backend.config.logging_config import configure_logging
+
+        logger = configure_logging(__name__)
 
         p = ParsedArgs(args)
 
@@ -186,19 +190,29 @@ def _register_all(reg: CommandRegistry) -> None:
             print("Use 'fit-update --help' for usage information.")
             return False
 
-        # Resolve the concrete DB alias.
-        # Priority: explicit --db-alias > unambiguous --market > interactive prompt.
-        # We prompt whenever we'd otherwise silently pick a backing DB:
-        #   - no --market flag (unspecified)
-        #   - --market=both (doesn't map to a single DB)
-        # Explicit --market=primary / --market=deployment pass through.
+        # Resolve the effective market_alias and its single-DB fallback.
+        # Priority: explicit --db-alias > explicit --market (incl. "both") > prompt/default.
+        # Explicit --market=both is preserved as-is; subcommands that iterate
+        # markets use _configured_market_db_aliases(market_flag) and need "both"
+        # intact. db_alias is only the single-DB fallback for subcommands that
+        # require one concrete DB.
         db_alias_override = p.get_string("db-alias")
         if db_alias_override:
             db_alias = db_alias_override
         else:
             explicit_market = resolve_market_alias(args)
-            if explicit_market is None or explicit_market not in MARKET_DB_MAP:
-                market_alias = resolve_market_alias_interactive(default="primary")
+            if explicit_market is None:
+                if sys.stdin.isatty():
+                    market_alias = resolve_market_alias_interactive(default="primary")
+                else:
+                    logger.warning(
+                        "fit-update: no --market specified in non-TTY context; "
+                        "defaulting to 'primary'. Pass --market=primary/deployment/both "
+                        "explicitly to silence this warning."
+                    )
+                    market_alias = "primary"
+            else:
+                market_alias = explicit_market
             db_alias = MARKET_DB_MAP.get(market_alias, MARKET_DB_MAP["primary"])
         paste_mode = p.has_flag("paste")
         file_path = None if paste_mode else p.get_string("file", "fit-file")

--- a/src/mkts_backend/cli_tools/command_registry.py
+++ b/src/mkts_backend/cli_tools/command_registry.py
@@ -162,6 +162,7 @@ def _register_all(reg: CommandRegistry) -> None:
         from mkts_backend.cli_tools.arg_utils import ParsedArgs, ArgError
         from mkts_backend.cli_tools.market_args import (
             MARKET_DB_MAP,
+            resolve_market_alias,
             resolve_market_alias_interactive,
         )
         from mkts_backend.cli_tools.fit_update import fit_update_command
@@ -185,21 +186,19 @@ def _register_all(reg: CommandRegistry) -> None:
             print("Use 'fit-update --help' for usage information.")
             return False
 
-        # Resolve the concrete DB alias to pass to single-DB subcommands.
-        # Subcommands that handle --market=both natively (assign-market,
-        # update-lead-ship, doctrine-add-fit, etc.) use market_alias directly,
-        # so db_alias is a sensible default for those that don't.
+        # Resolve the concrete DB alias.
+        # Priority: explicit --db-alias > unambiguous --market > interactive prompt.
+        # We prompt whenever we'd otherwise silently pick a backing DB:
+        #   - no --market flag (unspecified)
+        #   - --market=both (doesn't map to a single DB)
+        # Explicit --market=primary / --market=deployment pass through.
         db_alias_override = p.get_string("db-alias")
         if db_alias_override:
             db_alias = db_alias_override
-        elif market_alias in MARKET_DB_MAP:
-            db_alias = MARKET_DB_MAP[market_alias]
         else:
-            # Market alias covers multiple DBs (e.g. "both"). Prompt for a
-            # concrete pick rather than silently defaulting to the deprecated
-            # "wcmkt" alias. If the user re-picks "both" we default to primary
-            # as the backing DB; subcommands that support "both" use market_alias.
-            market_alias = resolve_market_alias_interactive(default="primary")
+            explicit_market = resolve_market_alias(args)
+            if explicit_market is None or explicit_market not in MARKET_DB_MAP:
+                market_alias = resolve_market_alias_interactive(default="primary")
             db_alias = MARKET_DB_MAP.get(market_alias, MARKET_DB_MAP["primary"])
         paste_mode = p.has_flag("paste")
         file_path = None if paste_mode else p.get_string("file", "fit-file")

--- a/src/mkts_backend/cli_tools/command_registry.py
+++ b/src/mkts_backend/cli_tools/command_registry.py
@@ -160,7 +160,10 @@ def _register_all(reg: CommandRegistry) -> None:
     # ── fit-update ──────────────────────────────────────────────
     def _handle_fit_update(args: list[str], market_alias: str) -> bool:
         from mkts_backend.cli_tools.arg_utils import ParsedArgs, ArgError
-        from mkts_backend.cli_tools.market_args import MARKET_DB_MAP
+        from mkts_backend.cli_tools.market_args import (
+            MARKET_DB_MAP,
+            resolve_market_alias_interactive,
+        )
         from mkts_backend.cli_tools.fit_update import fit_update_command
 
         p = ParsedArgs(args)
@@ -182,7 +185,22 @@ def _register_all(reg: CommandRegistry) -> None:
             print("Use 'fit-update --help' for usage information.")
             return False
 
-        db_alias = p.get_string("db-alias", default=MARKET_DB_MAP.get(market_alias, "wcmkt"))
+        # Resolve the concrete DB alias to pass to single-DB subcommands.
+        # Subcommands that handle --market=both natively (assign-market,
+        # update-lead-ship, doctrine-add-fit, etc.) use market_alias directly,
+        # so db_alias is a sensible default for those that don't.
+        db_alias_override = p.get_string("db-alias")
+        if db_alias_override:
+            db_alias = db_alias_override
+        elif market_alias in MARKET_DB_MAP:
+            db_alias = MARKET_DB_MAP[market_alias]
+        else:
+            # Market alias covers multiple DBs (e.g. "both"). Prompt for a
+            # concrete pick rather than silently defaulting to the deprecated
+            # "wcmkt" alias. If the user re-picks "both" we default to primary
+            # as the backing DB; subcommands that support "both" use market_alias.
+            market_alias = resolve_market_alias_interactive(default="primary")
+            db_alias = MARKET_DB_MAP.get(market_alias, MARKET_DB_MAP["primary"])
         paste_mode = p.has_flag("paste")
         file_path = None if paste_mode else p.get_string("file", "fit-file")
         meta_file = p.get_string("meta-file")

--- a/src/mkts_backend/cli_tools/fit_update.py
+++ b/src/mkts_backend/cli_tools/fit_update.py
@@ -6,12 +6,16 @@ Interactive tools for managing fits and doctrines:
 - update: Update an existing fit's items from file or pasted text
 - remove: Completely remove a fit from all doctrines and targets
 - assign-market: Assign market flags to fits
+- unassign-market: Remove a fit from one or all markets
 - list-fits: List all fits
 - list-doctrines: List all doctrines
 - create-doctrine: Create a new doctrine
 - doctrine-add-fit: Add existing fit(s) to a doctrine
 - doctrine-remove-fit: Remove fit(s) from a doctrine
 - update-target: Update the target quantity for a fit
+- update-lead-ship: Set or change the lead ship for a doctrine
+- update-friendly-name: Update the friendly_name for a doctrine
+- populate-friendly-names: Bulk-populate friendly_names from a JSON map
 
 Supports --paste mode for pasting EFT text directly via multiline prompt
 instead of requiring a file path.
@@ -743,10 +747,13 @@ def assign_doctrine_market(
     # Execute — skip per-fit confirmation since we just confirmed the whole batch
     result = _execute_market_plan(all_plans, remote, db_alias)
 
-    console.print(
+    summary = (
         f"\n[bold]Summary:[/bold] {result['updated']} updated, "
         f"{result['skipped']} skipped"
     )
+    if result.get("step_failures"):
+        summary += f", [red]{result['step_failures']} step failures[/red]"
+    console.print(summary)
     return result["updated"] > 0
 
 
@@ -772,8 +779,10 @@ def _needs_provisioning(
 ) -> bool:
     """Return True if a fit is missing doctrine_fits, doctrines, ship_targets, or lead_ships rows.
 
-    The lead_ships check is keyed on doctrine_id (not fit_id). Callers that
-    do not pass doctrine_id will skip the lead_ships check — legacy behavior.
+    ``doctrine_id`` is required to evaluate the lead_ships check (lead_ships
+    is keyed on doctrine_id, not fit_id). If ``doctrine_id`` is None, the
+    lead_ships check is skipped and this function cannot detect a missing
+    lead_ships row. All in-tree callers in fit_update.py pass doctrine_id.
     """
     def _check(c) -> bool:
         if doctrine_id is not None:
@@ -1161,8 +1170,31 @@ def _cleanup_market_db(
         engine.dispose()
 
 
-def _apply_step(conn, step_type: str, p: dict, arg) -> bool:
+def _report_lead_ship(adopted: bool, fit_id: int, doctrine_id: int) -> None:
+    """Emit a user-visible message describing lead_ships outcome.
+
+    ``adopted=True`` means a new lead_ships row was inserted for the doctrine;
+    ``adopted=False`` means an existing row was preserved (e.g. set by a prior
+    ``update-lead-ship`` call) and this provisioning did not override it. Users
+    running ``doctrine-add-fit`` against a doctrine with an explicit lead ship
+    need this signal to understand why their new fit did not become lead.
+    """
+    if adopted:
+        console.print(
+            f"  [green]Adopted[/green] fit {fit_id} as lead ship for doctrine {doctrine_id}"
+        )
+    else:
+        console.print(
+            f"  [dim]Lead ship for doctrine {doctrine_id} already set — preserved[/dim]"
+        )
+
+
+def _apply_step(conn, step_type: str, p: dict, arg, alias: str = "") -> bool:
     """Apply one provisioning step within a caller-owned transaction.
+
+    ``alias`` is the canonical DB alias this transaction targets; forwarded to
+    helpers that use it solely for log attribution. Defaults to "" for callers
+    that cannot yet thread it — those will see the helper's own default log.
 
     Returns True when the step did meaningful work (used to decide whether a
     heal plan counted as "updated" vs "skipped").
@@ -1173,16 +1205,18 @@ def _apply_step(conn, step_type: str, p: dict, arg) -> bool:
     if step_type == "update_and_heal":
         new_flag = arg
         update_fit_market_flag(
-            fit_id, new_flag, doctrine_id=doctrine_id, conn=conn,
+            fit_id, new_flag, doctrine_id=doctrine_id, db_alias=alias, conn=conn,
         )
         if _needs_provisioning(fit_id, "", conn=conn, doctrine_id=doctrine_id):
-            _provision_fit_in_market(conn=conn, p=p, market_flag=new_flag)
+            adopted = _provision_fit_in_market(conn=conn, p=p, market_flag=new_flag)
             console.print(f"  [green]Provisioned[/green] missing data for fit {fit_id}")
+            _report_lead_ship(adopted, fit_id, doctrine_id)
             return True
         return False
 
     if step_type == "provision":
-        _provision_fit_in_market(conn=conn, p=p, market_flag=arg)
+        adopted = _provision_fit_in_market(conn=conn, p=p, market_flag=arg)
+        _report_lead_ship(adopted, fit_id, doctrine_id)
         return True
 
     if step_type == "cleanup":
@@ -1192,8 +1226,9 @@ def _apply_step(conn, step_type: str, p: dict, arg) -> bool:
     if step_type == "heal_if_needed":
         new_flag = arg
         if _needs_provisioning(fit_id, "", conn=conn, doctrine_id=doctrine_id):
-            _provision_fit_in_market(conn=conn, p=p, market_flag=new_flag)
+            adopted = _provision_fit_in_market(conn=conn, p=p, market_flag=new_flag)
             console.print(f"  [green]Provisioned[/green] missing data for fit {fit_id}")
+            _report_lead_ship(adopted, fit_id, doctrine_id)
             return True
         return False
 
@@ -1220,8 +1255,22 @@ def _execute_market_plan(
     Returns aggregate counts: ``{"updated": int, "deleted": int, "skipped": int}``.
     """
     configured_aliases = _configured_market_db_aliases()
+    if not configured_aliases:
+        console.print(
+            "[red]Error: no markets configured — aborting plan execution.[/red] "
+            "Check `settings.toml` for a `[market.*]` section."
+        )
+        logger.error("_execute_market_plan aborted: _configured_market_db_aliases() returned []")
+        return {"updated": 0, "deleted": 0, "skipped": len(plans), "step_failures": 0}
+
+    # Canonicalize the caller's db_alias so "remove" buckets key on the same
+    # alias that "update" buckets derive from _flag_to_aliases. Without this,
+    # `db_alias="wcmkt"` and `alias="wcmktprod"` would open two engines against
+    # the same physical DB and defeat the batching.
+    canonical_db_alias = DatabaseConfig(db_alias).alias
+
     buckets: dict[tuple[bool, str], list] = defaultdict(list)
-    counters = {"updated": 0, "deleted": 0, "skipped": 0}
+    counters = {"updated": 0, "deleted": 0, "skipped": 0, "step_failures": 0}
     deleted_fit_ids: set[int] = set()
     heal_worked: dict[int, bool] = {}
     plan_by_fit: dict[int, dict] = {}
@@ -1259,7 +1308,7 @@ def _execute_market_plan(
             )
 
         elif action == "remove":
-            buckets[(False, db_alias)].append(("remove_row", p, None))
+            buckets[(False, canonical_db_alias)].append(("remove_row", p, None))
             if remote:
                 for alias in configured_aliases:
                     buckets[(True, alias)].append(("remove_row", p, None))
@@ -1282,28 +1331,65 @@ def _execute_market_plan(
                 for alias in non_target:
                     buckets[(True, alias)].append(("cleanup", p, None))
 
-    # Phase 2: prepare watchlists (outside transactions, idempotent)
+    # Phase 2: prepare watchlists (outside transactions, idempotent).
+    # Per-(fit, alias) error handling so one unreachable remote does not abort
+    # the entire plan — the remainder of Phase 3/4 for other buckets still runs.
     watchlist_needs: set[tuple[int, str, bool]] = set()
     for (is_remote, alias), steps in buckets.items():
         for step_type, p, _ in steps:
             if step_type in ("provision", "heal_if_needed", "update_and_heal"):
                 watchlist_needs.add((p["fit_id"], alias, is_remote))
     for fit_id_w, alias_w, remote_w in watchlist_needs:
-        _prepare_watchlist_for_fit(plan_by_fit[fit_id_w], alias_w, remote_w)
+        w_loc = f"{alias_w} ({'remote' if remote_w else 'local'})"
+        try:
+            _prepare_watchlist_for_fit(plan_by_fit[fit_id_w], alias_w, remote_w)
+        except (OperationalError, DatabaseError, ConnectionError, TimeoutError) as e:
+            console.print(
+                f"[yellow]Watchlist prep skipped for fit {fit_id_w} on {w_loc}: {e}[/yellow]"
+            )
+        except Exception as e:
+            console.print(
+                f"[red]Watchlist prep failed for fit {fit_id_w} on {w_loc}: {e}[/red]"
+            )
+            logger.exception("Unexpected error preparing watchlist for fit %s on %s", fit_id_w, w_loc)
 
-    # Phase 3: execute each bucket in a single transaction
+    # Phase 3: execute each bucket in a single transaction.
+    # Per-step try/except so a bad SDE lookup in one fit does not take down
+    # the other fits in the same bucket; DB errors (which the transaction must
+    # roll back as a whole) are caught at the outer level with the fit_id of
+    # the last-attempted step for diagnostics.
     for (is_remote, alias), steps in buckets.items():
         db = DatabaseConfig(alias)
         engine = db.remote_engine if is_remote else db.engine
         loc = f"{alias} ({'remote' if is_remote else 'local'})"
+        current_fit_id: int | None = None
         try:
             with engine.begin() as conn:
                 for step_type, p, arg in steps:
-                    did_work = _apply_step(conn, step_type, p, arg)
+                    current_fit_id = p["fit_id"]
+                    try:
+                        did_work = _apply_step(conn, step_type, p, arg, alias=alias)
+                    except (OperationalError, DatabaseError, ConnectionError, TimeoutError):
+                        # DB errors must abort the transaction — re-raise to
+                        # the outer handler which rolls the whole bucket back.
+                        raise
+                    except Exception as step_err:
+                        console.print(
+                            f"[red]Step {step_type} failed for fit {current_fit_id} on {loc}: "
+                            f"{step_err}[/red] (bucket continues)"
+                        )
+                        logger.exception(
+                            "Non-DB error in %s for fit %s on %s",
+                            step_type, current_fit_id, loc,
+                        )
+                        counters["step_failures"] += 1
+                        continue
                     if p["action"] == "heal" and did_work:
                         heal_worked[id(p)] = True
         except (OperationalError, DatabaseError, ConnectionError, TimeoutError) as e:
-            console.print(f"[yellow]Skipped {loc}: {e}[/yellow]")
+            console.print(
+                f"[yellow]Skipped {loc} (rolled back at fit {current_fit_id}): {e}[/yellow]"
+            )
         finally:
             engine.dispose()
 
@@ -1323,18 +1409,27 @@ def _execute_market_plan(
             db = DatabaseConfig(alias)
             engine = db.remote_engine if is_remote else db.engine
             loc = f"{alias} ({'remote' if is_remote else 'local'})"
+            current_fit_id = None
             try:
                 with engine.begin() as conn:
                     for fid in deleted_fit_ids:
+                        current_fit_id = fid
                         if _check_fit_orphaned(fid, conn=conn):
                             removed = remove_doctrines_for_fit(fid, conn=conn)
-                            remove_ship_target(fid, conn=conn)
+                            st_removed = remove_ship_target(fid, conn=conn)
                             if removed:
                                 console.print(
                                     f"  [dim]Cleaned up {removed} orphaned doctrines rows for fit {fid} on {loc}[/dim]"
                                 )
+                            if st_removed:
+                                console.print(
+                                    f"  [dim]Cleaned up ship_targets for fit {fid} on {loc}[/dim]"
+                                )
             except (OperationalError, DatabaseError, ConnectionError, TimeoutError) as e:
-                console.print(f"[yellow]Orphan cleanup skipped for {loc}: {e}[/yellow]")
+                console.print(
+                    f"[yellow]Orphan cleanup skipped for {loc} "
+                    f"(rolled back at fit {current_fit_id}): {e}[/yellow]"
+                )
             finally:
                 engine.dispose()
 
@@ -1492,10 +1587,13 @@ def unassign_doctrine_market(
     # Execute — skip per-fit confirmation since we just confirmed the whole batch
     result = _execute_market_plan(all_plans, remote, db_alias)
 
-    console.print(
+    summary = (
         f"\n[bold]Summary:[/bold] {result['updated']} updated, "
         f"{result['deleted']} removed, {result['skipped']} skipped"
     )
+    if result.get("step_failures"):
+        summary += f", [red]{result['step_failures']} step failures[/red]"
+    console.print(summary)
     return result["updated"] > 0 or result["deleted"] > 0
 
 
@@ -2053,9 +2151,11 @@ def doctrine_add_fit_command(
         db = DatabaseConfig(alias)
         engine = db.remote_engine if remote else db.engine
         loc = f"{alias} ({'remote' if remote else 'local'})"
+        current_fit_id: int | None = None
         try:
             with engine.begin() as conn:
                 for _, doctrine_fit, fit_target in prepared:
+                    current_fit_id = doctrine_fit.fit_id
                     p = {
                         "fit_id": doctrine_fit.fit_id,
                         "fit_name": doctrine_fit.fit_name,
@@ -2065,11 +2165,15 @@ def doctrine_add_fit_command(
                         "doctrine_name": doctrine_fit.doctrine_name,
                         "target": fit_target,
                     }
-                    _provision_fit_in_market(conn=conn, p=p, market_flag=market_flag)
+                    adopted = _provision_fit_in_market(conn=conn, p=p, market_flag=market_flag)
+                    _report_lead_ship(adopted, doctrine_fit.fit_id, doctrine_fit.doctrine_id)
             for _, doctrine_fit, _ in prepared:
                 fit_alias_success[doctrine_fit.fit_id] += 1
         except (OperationalError, DatabaseError, ConnectionError, TimeoutError) as e:
-            console.print(f"[yellow]Bucket {loc} failed: {e}[/yellow]")
+            console.print(
+                f"[yellow]Bucket {loc} failed "
+                f"(rolled back at fit {current_fit_id}): {e}[/yellow]"
+            )
             logger.exception(f"Error provisioning {alias} for doctrine {doctrine_id}")
         finally:
             engine.dispose()
@@ -2750,8 +2854,8 @@ def update_friendly_name_command(
         console.print(f"[red]No rows found for doctrine_id {doctrine_id}[/red]")
         return False
 
-    # Push to both remotes
-    for target in ("wcmkt", "wcmktnorth"):
+    # Push to every configured market's remote
+    for target in _configured_market_db_aliases():
         try:
             ensure_friendly_name_column(db_alias=target, remote=True)
             remote_ok = update_doctrine_friendly_name(doctrine_id, friendly_name, db_alias=target, remote=True)
@@ -2780,8 +2884,8 @@ def populate_friendly_names_command(
     count = populate_friendly_names_from_json(json_path, db_alias=db_alias, remote=False)
     console.print(f"[green]Updated {count} rows locally ({db_alias})[/green]")
 
-    # Sync local → both remotes (doctrine_fits should be identical on both)
-    for target in ("wcmkt", "wcmktnorth"):
+    # Sync local → every configured market's remote (doctrine_fits identical across)
+    for target in _configured_market_db_aliases():
         ok = sync_friendly_names_to_remote(source_alias=db_alias, target_alias=target)
         if ok:
             console.print(f"[green]Synced friendly_names to remote ({target})[/green]")

--- a/src/mkts_backend/cli_tools/fit_update.py
+++ b/src/mkts_backend/cli_tools/fit_update.py
@@ -17,6 +17,7 @@ Supports --paste mode for pasting EFT text directly via multiline prompt
 instead of requiring a file path.
 """
 
+from collections import defaultdict
 from typing import List, Optional
 from rich.console import Console
 from rich.table import Table
@@ -68,14 +69,21 @@ logger = configure_logging(__name__)
 console = Console()
 
 
-def _configured_market_db_aliases() -> List[str]:
-    """Return the per-market database aliases from settings.toml.
+def _configured_market_db_aliases(market_flag: Optional[str] = None) -> List[str]:
+    """Return DB aliases for configured markets, optionally filtered by market_flag.
 
-    Callers should use this instead of naming market DB aliases inline,
-    which would silently miss markets added later.
+    ``market_flag`` may be ``primary``, ``deployment``, or ``both`` — when
+    provided, aliases are resolved via ``expand_market_alias``. When None
+    (default), returns every configured market's DB alias. Always
+    config-driven so new markets are picked up automatically.
     """
+    if market_flag is None:
+        markets = MarketContext.list_available()
+    else:
+        from mkts_backend.cli_tools.market_args import expand_market_alias
+        markets = expand_market_alias(market_flag)
     aliases: List[str] = []
-    for market in MarketContext.list_available():
+    for market in markets:
         try:
             db_alias = MarketContext.from_settings(market).database_alias
         except Exception as e:
@@ -534,7 +542,7 @@ def interactive_add_fit(
     try:
         # Determine which databases to update
         if market_flag == "both":
-            target_aliases = ["wcmkt", "wcmktnorth"]
+            target_aliases = _configured_market_db_aliases()
         else:
             target_aliases = [target_alias]
 
@@ -759,39 +767,53 @@ def _needs_provisioning(
     db_alias: str,
     remote: bool = False,
     engine=None,
+    conn=None,
     doctrine_id: int | None = None,
 ) -> bool:
-    """Return True if a fit is missing doctrine_fits, doctrines, or ship_targets rows in a database."""
-    if engine is None:
-        db = DatabaseConfig(db_alias)
-        _engine = db.remote_engine if remote else db.engine
-    else:
-        _engine = engine
-    try:
-        with _engine.connect() as conn:
-            # Check doctrine_fits (the row update_fit_market_flag targets)
-            if doctrine_id is not None:
-                df = conn.execute(
-                    text(
-                        "SELECT 1 FROM doctrine_fits "
-                        "WHERE fit_id = :fit_id AND doctrine_id = :doctrine_id"
-                    ),
-                    {"fit_id": fit_id, "doctrine_id": doctrine_id},
-                ).fetchone()
-            else:
-                df = conn.execute(
-                    text("SELECT 1 FROM doctrine_fits WHERE fit_id = :fit_id"),
-                    {"fit_id": fit_id},
-                ).fetchone()
-            doc_count = conn.execute(
-                text("SELECT COUNT(*) FROM doctrines WHERE fit_id = :fit_id"),
-                {"fit_id": fit_id},
-            ).fetchone()[0]
-            st = conn.execute(
-                text("SELECT 1 FROM ship_targets WHERE fit_id = :fit_id"),
+    """Return True if a fit is missing doctrine_fits, doctrines, ship_targets, or lead_ships rows.
+
+    The lead_ships check is keyed on doctrine_id (not fit_id). Callers that
+    do not pass doctrine_id will skip the lead_ships check — legacy behavior.
+    """
+    def _check(c) -> bool:
+        if doctrine_id is not None:
+            df = c.execute(
+                text(
+                    "SELECT 1 FROM doctrine_fits "
+                    "WHERE fit_id = :fit_id AND doctrine_id = :doctrine_id"
+                ),
+                {"fit_id": fit_id, "doctrine_id": doctrine_id},
+            ).fetchone()
+        else:
+            df = c.execute(
+                text("SELECT 1 FROM doctrine_fits WHERE fit_id = :fit_id"),
                 {"fit_id": fit_id},
             ).fetchone()
-        return df is None or doc_count == 0 or st is None
+        doc_count = c.execute(
+            text("SELECT COUNT(*) FROM doctrines WHERE fit_id = :fit_id"),
+            {"fit_id": fit_id},
+        ).fetchone()[0]
+        st = c.execute(
+            text("SELECT 1 FROM ship_targets WHERE fit_id = :fit_id"),
+            {"fit_id": fit_id},
+        ).fetchone()
+        ls_missing = False
+        if doctrine_id is not None:
+            ls = c.execute(
+                text("SELECT 1 FROM lead_ships WHERE doctrine_id = :doctrine_id"),
+                {"doctrine_id": doctrine_id},
+            ).fetchone()
+            ls_missing = ls is None
+        return df is None or doc_count == 0 or st is None or ls_missing
+
+    if conn is not None:
+        return _check(conn)
+    _engine = engine if engine is not None else (
+        DatabaseConfig(db_alias).remote_engine if remote else DatabaseConfig(db_alias).engine
+    )
+    try:
+        with _engine.connect() as c:
+            return _check(c)
     finally:
         if engine is None:
             _engine.dispose()
@@ -802,21 +824,26 @@ def _check_fit_orphaned(
     db_alias: str = "wcmkt",
     remote: bool = False,
     engine=None,
+    conn=None,
 ) -> bool:
     """Return True if fit_id has no remaining doctrine_fits rows."""
-    if engine is None:
-        db = DatabaseConfig(db_alias)
-        _engine = db.remote_engine if remote else db.engine
-    else:
-        _engine = engine
-    with _engine.connect() as conn:
-        result = conn.execute(
+    def _do(c):
+        return c.execute(
             text("SELECT COUNT(*) FROM doctrine_fits WHERE fit_id = :fit_id"),
             {"fit_id": fit_id},
-        ).fetchone()
-    if engine is None:
-        _engine.dispose()
-    return result[0] == 0
+        ).fetchone()[0] == 0
+
+    if conn is not None:
+        return _do(conn)
+    _engine = engine if engine is not None else (
+        DatabaseConfig(db_alias).remote_engine if remote else DatabaseConfig(db_alias).engine
+    )
+    try:
+        with _engine.connect() as c:
+            return _do(c)
+    finally:
+        if engine is None:
+            _engine.dispose()
 
 
 def _get_doctrine_fits_rows(
@@ -1011,56 +1038,111 @@ def _display_market_preview(
     console.print(f"  Planned: {', '.join(parts)}\n")
 
 
+def _prepare_watchlist_for_fit(p: dict, alias: str, remote: bool) -> None:
+    """Ensure all component type_ids for a fit are present in the market DB's watchlist.
+
+    Runs outside the provisioning transaction because it touches a separate
+    table on the same DB and is idempotent — keeping it standalone avoids
+    lock contention with the caller's engine.begin() block.
+    """
+    fittings_db = DatabaseConfig("fittings")
+    fittings_engine = fittings_db.engine
+    try:
+        with fittings_engine.connect() as conn:
+            item_rows = conn.execute(
+                text("SELECT DISTINCT type_id FROM fittings_fittingitem WHERE fit_id = :fit_id"),
+                {"fit_id": p["fit_id"]},
+            ).fetchall()
+    finally:
+        fittings_engine.dispose()
+    component_ids = [r.type_id for r in item_rows]
+    component_ids.append(p["ship_type_id"])
+    add_missing_items_to_watchlist(component_ids, remote=remote, db_alias=alias)
+
+
+def _provision_fit_in_market(
+    conn,
+    p: dict,
+    market_flag: str,
+) -> bool:
+    """Write every per-fit-per-market row inside the caller's transaction.
+
+    Upserts doctrine_fits / doctrine_map / ship_targets, rebuilds the
+    ``doctrines`` rows for this fit, and inserts a ``lead_ships`` row only
+    when none exists for the doctrine — so the first fit added "adopts" a
+    doctrine but an explicit user pick via ``update-lead-ship`` is never
+    overwritten.
+
+    Caller owns the transaction (commit happens on ``with engine.begin()``
+    exit). Returns True when a new lead_ship row was inserted.
+    """
+    doctrine_fit = DoctrineFit.from_resolved(
+        doctrine_id=p["doctrine_id"],
+        fit_id=p["fit_id"],
+        target=p["target"],
+        doctrine_name=p["doctrine_name"],
+        fit_name=p["fit_name"],
+        ship_type_id=p["ship_type_id"],
+        ship_name=p["ship_name"],
+    )
+    upsert_doctrine_fits(doctrine_fit, market_flag=market_flag, conn=conn)
+    upsert_doctrine_map(p["doctrine_id"], p["fit_id"], conn=conn)
+    upsert_ship_target(
+        p["fit_id"], p["fit_name"], p["ship_type_id"], p["ship_name"],
+        p["target"], conn=conn,
+    )
+    refresh_doctrines_for_fit(p["fit_id"], p["ship_type_id"], p["ship_name"], conn=conn)
+    return upsert_lead_ship(
+        doctrine_id=p["doctrine_id"],
+        doctrine_name=p["doctrine_name"],
+        fit_id=p["fit_id"],
+        ship_type_id=p["ship_type_id"],
+        conn=conn,
+    )
+
+
 def _provision_market_db(
     p: dict,
     alias: str,
     new_flag: str,
     remote: bool,
 ) -> None:
-    """Provision all tables for a fit in a newly-assigned market database.
+    """Legacy entry point: provision a single fit using its own engine + transaction.
 
-    Creates a single engine for all operations to avoid multiple concurrent
-    connections to the same SQLite file.
+    Kept so callers that do one-off provisioning (without bucketing) still
+    work. Bulk callers should use ``_provision_fit_in_market`` directly
+    inside a shared ``engine.begin()`` block.
     """
+    _prepare_watchlist_for_fit(p, alias, remote)
     db = DatabaseConfig(alias)
     engine = db.remote_engine if remote else db.engine
     try:
-        doctrine_fit = DoctrineFit.from_resolved(
-            doctrine_id=p["doctrine_id"],
-            fit_id=p["fit_id"],
-            target=p["target"],
-            doctrine_name=p["doctrine_name"],
-            fit_name=p["fit_name"],
-            ship_type_id=p["ship_type_id"],
-            ship_name=p["ship_name"],
-        )
-        # Ensure all fit components exist in the target database's watchlist
-        fittings_db = DatabaseConfig("fittings")
-        fittings_engine = fittings_db.engine
-        try:
-            with fittings_engine.connect() as conn:
-                item_rows = conn.execute(
-                    text("SELECT DISTINCT type_id FROM fittings_fittingitem WHERE fit_id = :fit_id"),
-                    {"fit_id": p["fit_id"]},
-                ).fetchall()
-            component_ids = [r.type_id for r in item_rows]
-            component_ids.append(p["ship_type_id"])
-            add_missing_items_to_watchlist(component_ids, remote=remote, db_alias=alias)
-        finally:
-            fittings_engine.dispose()
-
-        upsert_doctrine_fits(doctrine_fit, remote=remote, db_alias=alias, market_flag=new_flag, engine=engine)
-        upsert_doctrine_map(p["doctrine_id"], p["fit_id"], remote=remote, db_alias=alias, engine=engine)
-        upsert_ship_target(
-            p["fit_id"], p["fit_name"], p["ship_type_id"], p["ship_name"],
-            p["target"], remote=remote, db_alias=alias, engine=engine,
-        )
-        refresh_doctrines_for_fit(
-            p["fit_id"], p["ship_type_id"], p["ship_name"],
-            remote=remote, db_alias=alias, engine=engine,
-        )
+        with engine.begin() as conn:
+            _provision_fit_in_market(conn=conn, p=p, market_flag=new_flag)
     finally:
         engine.dispose()
+
+
+def _cleanup_fit_in_market(
+    conn,
+    fit_id: int,
+    doctrine_id: int,
+) -> None:
+    """Remove doctrine_fits / doctrine_map for a fit inside a caller's transaction;
+    if the fit is now orphaned, also strip its doctrines + ship_targets rows.
+    """
+    remove_doctrine_fits(doctrine_id, fit_id, conn=conn)
+    remove_doctrine_map(doctrine_id, fit_id, conn=conn)
+    orphan_check = conn.execute(
+        text("SELECT COUNT(*) FROM doctrine_fits WHERE fit_id = :fit_id"),
+        {"fit_id": fit_id},
+    ).fetchone()
+    if orphan_check and orphan_check[0] == 0:
+        removed = remove_doctrines_for_fit(fit_id, conn=conn)
+        if removed:
+            console.print(f"  [dim]Cleaned up {removed} orphaned doctrines rows for fit {fit_id}[/dim]")
+        remove_ship_target(fit_id, conn=conn)
+        console.print(f"  [dim]Cleaned up ship_targets for fit {fit_id}[/dim]")
 
 
 def _cleanup_market_db(
@@ -1069,20 +1151,58 @@ def _cleanup_market_db(
     alias: str,
     remote: bool,
 ) -> None:
-    """Remove a fit's doctrine_fits/doctrine_map from a market database,
-    then clean up doctrines/ship_targets if the fit is orphaned.
-
-    Creates a single engine for all operations.
-    """
+    """Legacy entry point for cleanup on a dedicated engine + transaction."""
     db = DatabaseConfig(alias)
     engine = db.remote_engine if remote else db.engine
     try:
-        remove_doctrine_fits(doctrine_id, fit_id, remote=remote, db_alias=alias, engine=engine)
-        remove_doctrine_map(doctrine_id, fit_id, remote=remote, db_alias=alias, engine=engine)
-        if _check_fit_orphaned(fit_id, alias, remote=remote, engine=engine):
-            _cleanup_orphaned_fit(fit_id, alias, remote=remote, engine=engine)
+        with engine.begin() as conn:
+            _cleanup_fit_in_market(conn, fit_id, doctrine_id)
     finally:
         engine.dispose()
+
+
+def _apply_step(conn, step_type: str, p: dict, arg) -> bool:
+    """Apply one provisioning step within a caller-owned transaction.
+
+    Returns True when the step did meaningful work (used to decide whether a
+    heal plan counted as "updated" vs "skipped").
+    """
+    fit_id = p["fit_id"]
+    doctrine_id = p["doctrine_id"]
+
+    if step_type == "update_and_heal":
+        new_flag = arg
+        update_fit_market_flag(
+            fit_id, new_flag, doctrine_id=doctrine_id, conn=conn,
+        )
+        if _needs_provisioning(fit_id, "", conn=conn, doctrine_id=doctrine_id):
+            _provision_fit_in_market(conn=conn, p=p, market_flag=new_flag)
+            console.print(f"  [green]Provisioned[/green] missing data for fit {fit_id}")
+            return True
+        return False
+
+    if step_type == "provision":
+        _provision_fit_in_market(conn=conn, p=p, market_flag=arg)
+        return True
+
+    if step_type == "cleanup":
+        _cleanup_fit_in_market(conn, fit_id, doctrine_id)
+        return True
+
+    if step_type == "heal_if_needed":
+        new_flag = arg
+        if _needs_provisioning(fit_id, "", conn=conn, doctrine_id=doctrine_id):
+            _provision_fit_in_market(conn=conn, p=p, market_flag=new_flag)
+            console.print(f"  [green]Provisioned[/green] missing data for fit {fit_id}")
+            return True
+        return False
+
+    if step_type == "remove_row":
+        remove_doctrine_fits(doctrine_id, fit_id, conn=conn)
+        remove_doctrine_map(doctrine_id, fit_id, conn=conn)
+        return True
+
+    raise ValueError(f"Unknown step type: {step_type}")
 
 
 def _execute_market_plan(
@@ -1090,149 +1210,135 @@ def _execute_market_plan(
     remote: bool,
     db_alias: str,
 ) -> dict:
-    """Execute a list of planned assign or unassign actions.
+    """Execute a list of planned assign / unassign / heal actions.
 
-    For "update" actions, computes which databases are newly added, removed,
-    or unchanged by the flag transition, then provisions/cleans up accordingly.
+    Groups every write by (is_remote, alias) so each database is touched from
+    exactly one engine and inside exactly one transaction per command
+    invocation. For an N-fit doctrine this produces at most
+    ``2 × len(configured markets)`` engines instead of one per helper call.
 
-    Always writes to the local database first.  When remote=True, mirrors
-    every change to both remote databases (wcmktprod, wcmktnorth).
-
-    Returns aggregate counts: {"updated": int, "deleted": int, "skipped": int}
+    Returns aggregate counts: ``{"updated": int, "deleted": int, "skipped": int}``.
     """
-    updated = 0
-    deleted = 0
-    skipped = 0
-    deleted_fit_ids = set()
+    configured_aliases = _configured_market_db_aliases()
+    buckets: dict[tuple[bool, str], list] = defaultdict(list)
+    counters = {"updated": 0, "deleted": 0, "skipped": 0}
+    deleted_fit_ids: set[int] = set()
+    heal_worked: dict[int, bool] = {}
+    plan_by_fit: dict[int, dict] = {}
 
+    # Phase 1: bucket every action by (is_remote, alias)
     for p in plans:
         fit_id = p["fit_id"]
-        row_doctrine_id = p["doctrine_id"]
+        doc_id = p["doctrine_id"]
+        plan_by_fit[fit_id] = p
+        action = p["action"]
 
-        if p["action"] == "update":
-            old_flag = p["market_flag"]
+        if action == "update":
+            old_aliases = _flag_to_aliases(p["market_flag"])
+            new_aliases = _flag_to_aliases(p["new_flag"])
             new_flag = p["new_flag"]
-            old_aliases = _flag_to_aliases(old_flag)
-            new_aliases = _flag_to_aliases(new_flag)
-            newly_added = new_aliases - old_aliases
-            newly_removed = old_aliases - new_aliases
-            unchanged = old_aliases & new_aliases
 
-            # Update flag in databases that remain active, heal if needed
-            for alias in unchanged:
-                update_fit_market_flag(
-                    fit_id, new_flag, remote=False, db_alias=alias,
-                    doctrine_id=row_doctrine_id,
-                )
-                if _needs_provisioning(fit_id, alias, remote=False, doctrine_id=row_doctrine_id):
-                    _provision_market_db(p, alias, new_flag, remote=False)
-                    console.print(f"  [green]Provisioned[/green] missing data for fit {fit_id} in {alias}")
+            for alias in old_aliases & new_aliases:
+                buckets[(False, alias)].append(("update_and_heal", p, new_flag))
+            for alias in new_aliases - old_aliases:
+                buckets[(False, alias)].append(("provision", p, new_flag))
+            for alias in old_aliases - new_aliases:
+                buckets[(False, alias)].append(("cleanup", p, None))
 
-            # Full provisioning in newly-added databases
-            for alias in newly_added:
-                _provision_market_db(p, alias, new_flag, remote=False)
-
-            # Full cleanup in newly-removed databases
-            for alias in newly_removed:
-                _cleanup_market_db(fit_id, row_doctrine_id, alias, remote=False)
-
-            # Remote mirroring — reconcile each remote DB to match new_flag,
-            # regardless of what the remote's current state is (handles drift).
             if remote:
-                for target in ("wcmktprod", "wcmktnorth"):
-                    try:
-                        if target in new_aliases:
-                            # This DB should have the fit — update flag and heal if needed
-                            update_fit_market_flag(
-                                fit_id, new_flag, remote=True, db_alias=target,
-                                doctrine_id=row_doctrine_id,
-                            )
-                            if _needs_provisioning(fit_id, target, remote=True, doctrine_id=row_doctrine_id):
-                                _provision_market_db(p, target, new_flag, remote=True)
-                                console.print(f"  [green]Provisioned[/green] missing remote data for fit {fit_id} in {target}")
-                        else:
-                            # This DB should NOT have the fit — clean up if present
-                            _cleanup_market_db(fit_id, row_doctrine_id, target, remote=True)
-                    except (OperationalError, DatabaseError, ConnectionError, TimeoutError) as e:
-                        console.print(
-                            f"[yellow]Remote update skipped for {target}: {e}[/yellow]"
-                        )
+                for alias in configured_aliases:
+                    if alias in new_aliases:
+                        buckets[(True, alias)].append(("update_and_heal", p, new_flag))
+                    else:
+                        buckets[(True, alias)].append(("cleanup", p, None))
 
-            updated += 1
+            counters["updated"] += 1
             console.print(
-                f"  [green]Updated[/green] fit {fit_id}: "
-                f"market_flag '{old_flag}' -> '{new_flag}'"
+                f"  [green]Planned update[/green] fit {fit_id}: "
+                f"market_flag '{p['market_flag']}' -> '{new_flag}'"
             )
 
-        elif p["action"] == "remove":
-            # Local
-            remove_doctrine_fits(row_doctrine_id, fit_id, remote=False, db_alias=db_alias)
-            remove_doctrine_map(row_doctrine_id, fit_id, remote=False, db_alias=db_alias)
-            # Remote
+        elif action == "remove":
+            buckets[(False, db_alias)].append(("remove_row", p, None))
             if remote:
-                for target in ("wcmktprod", "wcmktnorth"):
-                    try:
-                        remove_doctrine_fits(row_doctrine_id, fit_id, remote=True, db_alias=target)
-                        remove_doctrine_map(row_doctrine_id, fit_id, remote=True, db_alias=target)
-                    except (OperationalError, DatabaseError, ConnectionError, TimeoutError) as e:
-                        console.print(
-                            f"[yellow]Remote remove skipped for {target}: {e}[/yellow]"
-                        )
-            deleted += 1
+                for alias in configured_aliases:
+                    buckets[(True, alias)].append(("remove_row", p, None))
             deleted_fit_ids.add(fit_id)
+            counters["deleted"] += 1
             console.print(
-                f"  [red]Removed[/red] fit {fit_id} from doctrine {row_doctrine_id} "
+                f"  [red]Planned remove[/red] fit {fit_id} from doctrine {doc_id} "
                 f"({p.get('doctrine_name', '?')})"
             )
-        else:
-            # Heal: even when flag matches, reconcile all databases to match
+
+        else:  # heal
+            heal_worked[id(p)] = False
             target_aliases = _flag_to_aliases(p["new_flag"])
-            non_target_aliases = {"wcmktprod", "wcmktnorth"} - target_aliases
-            healed = False
+            non_target = set(configured_aliases) - target_aliases
             for alias in target_aliases:
-                if _needs_provisioning(fit_id, alias, remote=False, doctrine_id=row_doctrine_id):
-                    _provision_market_db(p, alias, p["new_flag"], remote=False)
-                    console.print(f"  [green]Provisioned[/green] missing data for fit {fit_id} in {alias}")
-                    healed = True
+                buckets[(False, alias)].append(("heal_if_needed", p, p["new_flag"]))
             if remote:
                 for alias in target_aliases:
-                    try:
-                        update_fit_market_flag(
-                            fit_id, p["new_flag"], remote=True, db_alias=alias,
-                            doctrine_id=row_doctrine_id,
-                        )
-                        if _needs_provisioning(fit_id, alias, remote=True, doctrine_id=row_doctrine_id):
-                            _provision_market_db(p, alias, p["new_flag"], remote=True)
-                            console.print(f"  [green]Provisioned[/green] missing remote data for fit {fit_id} in {alias}")
-                            healed = True
-                    except (OperationalError, DatabaseError, ConnectionError, TimeoutError) as e:
-                        console.print(f"[yellow]Remote provisioning skipped for {alias}: {e}[/yellow]")
-                for alias in non_target_aliases:
-                    try:
-                        _cleanup_market_db(fit_id, row_doctrine_id, alias, remote=True)
-                    except (OperationalError, DatabaseError, ConnectionError, TimeoutError) as e:
-                        console.print(f"[yellow]Remote cleanup skipped for {alias}: {e}[/yellow]")
-            if healed:
-                updated += 1
-            else:
-                skipped += 1
+                    buckets[(True, alias)].append(("update_and_heal", p, p["new_flag"]))
+                for alias in non_target:
+                    buckets[(True, alias)].append(("cleanup", p, None))
 
-    # Orphan cleanup for any deleted fits (check all local alias databases)
-    for fit_id in deleted_fit_ids:
-        for local_alias in ("wcmktprod", "wcmktnorth"):
-            if _check_fit_orphaned(fit_id, local_alias, remote=False):
-                _cleanup_orphaned_fit(fit_id, local_alias, remote=False)
+    # Phase 2: prepare watchlists (outside transactions, idempotent)
+    watchlist_needs: set[tuple[int, str, bool]] = set()
+    for (is_remote, alias), steps in buckets.items():
+        for step_type, p, _ in steps:
+            if step_type in ("provision", "heal_if_needed", "update_and_heal"):
+                watchlist_needs.add((p["fit_id"], alias, is_remote))
+    for fit_id_w, alias_w, remote_w in watchlist_needs:
+        _prepare_watchlist_for_fit(plan_by_fit[fit_id_w], alias_w, remote_w)
+
+    # Phase 3: execute each bucket in a single transaction
+    for (is_remote, alias), steps in buckets.items():
+        db = DatabaseConfig(alias)
+        engine = db.remote_engine if is_remote else db.engine
+        loc = f"{alias} ({'remote' if is_remote else 'local'})"
+        try:
+            with engine.begin() as conn:
+                for step_type, p, arg in steps:
+                    did_work = _apply_step(conn, step_type, p, arg)
+                    if p["action"] == "heal" and did_work:
+                        heal_worked[id(p)] = True
+        except (OperationalError, DatabaseError, ConnectionError, TimeoutError) as e:
+            console.print(f"[yellow]Skipped {loc}: {e}[/yellow]")
+        finally:
+            engine.dispose()
+
+    # Heal counters — a heal counts as "updated" iff any bucket did work
+    for pid, did in heal_worked.items():
+        if did:
+            counters["updated"] += 1
+        else:
+            counters["skipped"] += 1
+
+    # Phase 4: orphan cleanup for deleted fits (one transaction per alias)
+    if deleted_fit_ids:
+        orphan_targets: list[tuple[bool, str]] = [(False, a) for a in configured_aliases]
         if remote:
-            for target in ("wcmktprod", "wcmktnorth"):
-                try:
-                    if _check_fit_orphaned(fit_id, target, remote=True):
-                        _cleanup_orphaned_fit(fit_id, target, remote=True)
-                except (OperationalError, DatabaseError, ConnectionError, TimeoutError) as e:
-                    console.print(
-                        f"[yellow]Remote orphan cleanup skipped for {target}: {e}[/yellow]"
-                    )
+            orphan_targets += [(True, a) for a in configured_aliases]
+        for is_remote, alias in orphan_targets:
+            db = DatabaseConfig(alias)
+            engine = db.remote_engine if is_remote else db.engine
+            loc = f"{alias} ({'remote' if is_remote else 'local'})"
+            try:
+                with engine.begin() as conn:
+                    for fid in deleted_fit_ids:
+                        if _check_fit_orphaned(fid, conn=conn):
+                            removed = remove_doctrines_for_fit(fid, conn=conn)
+                            remove_ship_target(fid, conn=conn)
+                            if removed:
+                                console.print(
+                                    f"  [dim]Cleaned up {removed} orphaned doctrines rows for fit {fid} on {loc}[/dim]"
+                                )
+            except (OperationalError, DatabaseError, ConnectionError, TimeoutError) as e:
+                console.print(f"[yellow]Orphan cleanup skipped for {loc}: {e}[/yellow]")
+            finally:
+                engine.dispose()
 
-    return {"updated": updated, "deleted": deleted, "skipped": skipped}
+    return counters
 
 
 def unassign_market_command(
@@ -1664,7 +1770,7 @@ def doctrine_add_fit_command(
 
     # Determine target market databases up front (used for both validation and writes)
     if market_flag == "both":
-        target_aliases = ["wcmkt", "wcmktnorth"]
+        target_aliases = _configured_market_db_aliases()
     else:
         target_aliases = [db_alias]
 
@@ -1913,70 +2019,86 @@ def doctrine_add_fit_command(
     success_count = 0
     fail_count = 0
 
+    # Stage 1: per-fit preparation (fittings DB link + DoctrineFit resolution).
+    # Independent of market DBs; failures here skip the fit entirely.
+    prepared: list[tuple[dict, DoctrineFit, int]] = []
     for fit_info in valid_fits:
         fit_id = fit_info["fit_id"]
-        fit_target = fit_targets.get(fit_id, target)  # Get per-fit target
+        fit_target = fit_targets.get(fit_id, target)
         try:
-            # Link in fittings database (shared, only done once)
             ensure_doctrine_link(doctrine_id, fit_id, remote=remote)
-
             doctrine_fit = DoctrineFit(
                 doctrine_id=doctrine_id,
                 fit_id=fit_id,
                 target=fit_target,
             )
+            prepared.append((fit_info, doctrine_fit, fit_target))
+        except Exception as e:
+            console.print(f"[red]✗ Failed to prepare fit {fit_id}: {e}[/red]")
+            logger.exception(f"Error preparing fit {fit_id} for doctrine {doctrine_id}")
+            fail_count += 1
 
-            # Add to each target market database
-            for alias in target_aliases:
-                upsert_doctrine_fits(
-                    doctrine_fit=doctrine_fit,
-                    remote=remote,
-                    db_alias=alias,
-                    market_flag=market_flag,
-                )
+    # Stage 2: watchlist prep per (fit, alias) — idempotent, outside any transaction.
+    for alias in target_aliases:
+        for _, doctrine_fit, _ in prepared:
+            p_like = {
+                "fit_id": doctrine_fit.fit_id,
+                "ship_type_id": doctrine_fit.ship_type_id,
+            }
+            _prepare_watchlist_for_fit(p_like, alias, remote)
 
-                upsert_doctrine_map(doctrine_id, fit_id,
-                                    remote=remote, db_alias=alias)
+    # Stage 3: one transaction per market DB — all fits for that DB in one batch.
+    fit_alias_success: dict[int, int] = {df.fit_id: 0 for _, df, _ in prepared}
+    for alias in target_aliases:
+        db = DatabaseConfig(alias)
+        engine = db.remote_engine if remote else db.engine
+        loc = f"{alias} ({'remote' if remote else 'local'})"
+        try:
+            with engine.begin() as conn:
+                for _, doctrine_fit, fit_target in prepared:
+                    p = {
+                        "fit_id": doctrine_fit.fit_id,
+                        "fit_name": doctrine_fit.fit_name,
+                        "ship_type_id": doctrine_fit.ship_type_id,
+                        "ship_name": doctrine_fit.ship_name,
+                        "doctrine_id": doctrine_fit.doctrine_id,
+                        "doctrine_name": doctrine_fit.doctrine_name,
+                        "target": fit_target,
+                    }
+                    _provision_fit_in_market(conn=conn, p=p, market_flag=market_flag)
+            for _, doctrine_fit, _ in prepared:
+                fit_alias_success[doctrine_fit.fit_id] += 1
+        except (OperationalError, DatabaseError, ConnectionError, TimeoutError) as e:
+            console.print(f"[yellow]Bucket {loc} failed: {e}[/yellow]")
+            logger.exception(f"Error provisioning {alias} for doctrine {doctrine_id}")
+        finally:
+            engine.dispose()
 
-                upsert_ship_target(
-                    fit_id=fit_id,
-                    fit_name=doctrine_fit.fit_name,
-                    ship_id=doctrine_fit.ship_type_id,
-                    ship_name=doctrine_fit.ship_name,
-                    ship_target=fit_target,
-                    remote=remote,
-                    db_alias=alias,
-                )
-
-                refresh_doctrines_for_fit(
-                    fit_id=fit_id,
-                    ship_id=doctrine_fit.ship_type_id,
-                    ship_name=doctrine_fit.ship_name,
-                    remote=remote,
-                    db_alias=alias,
-                )
-
+    # Per-fit success reporting
+    for _, doctrine_fit, fit_target in prepared:
+        n_ok = fit_alias_success[doctrine_fit.fit_id]
+        if n_ok == len(target_aliases):
             db_label = " + ".join(target_aliases)
             console.print(
-                f"[green]✓ Added fit {fit_id}: {doctrine_fit.fit_name} (target: {
-                    fit_target
-                }) [{db_label}][/green]"
+                f"[green]✓ Added fit {doctrine_fit.fit_id}: {doctrine_fit.fit_name} "
+                f"(target: {fit_target}) [{db_label}][/green]"
             )
             success_count += 1
-
-        except Exception as e:
-            console.print(f"[red]✗ Failed to add fit {fit_id}: {e}[/red]")
-            logger.exception(f"Error adding fit {
-                             fit_id} to doctrine {doctrine_id}")
+        elif n_ok > 0:
+            console.print(
+                f"[yellow]⚠ Partial: fit {doctrine_fit.fit_id} added to "
+                f"{n_ok}/{len(target_aliases)} markets[/yellow]"
+            )
+            success_count += 1
+        else:
+            console.print(f"[red]✗ Failed to add fit {doctrine_fit.fit_id}[/red]")
             fail_count += 1
 
     # Summary
     console.print()
     if success_count > 0:
         console.print(
-            f"[green]Successfully added {success_count} fit(s) to doctrine {
-                doctrine_id
-            }[/green]"
+            f"[green]Successfully added {success_count} fit(s) to doctrine {doctrine_id}[/green]"
         )
     if fail_count > 0:
         console.print(f"[red]Failed to add {fail_count} fit(s)[/red]")
@@ -2135,20 +2257,15 @@ def remove_fit_command(
 def update_lead_ship_command(
     doctrine_id: int,
     fit_id: int,
+    market_flag: str,
     remote: bool = False,
-    db_alias: str = "wcmkt",
 ) -> bool:
     """
-    Set or change the lead ship for a doctrine.
+    Set or change the lead ship for a doctrine across one or more markets.
 
-    Args:
-        doctrine_id: The doctrine to update
-        fit_id: The fit whose ship becomes the lead
-        remote: Use remote database
-        db_alias: Target market database alias
-
-    Returns:
-        True if successful
+    ``market_flag`` must be ``primary``, ``deployment``, or ``both``; the
+    list of target DB aliases is resolved from settings via
+    ``_configured_market_db_aliases``.
     """
     # Validate doctrine exists
     doctrines = get_available_doctrines(remote=remote)
@@ -2167,6 +2284,18 @@ def update_lead_ship_command(
         console.print(f"[red]Error: Fit {fit_id} not found[/red]")
         return False
 
+    # Resolve target DB aliases from the market flag
+    try:
+        target_aliases = _configured_market_db_aliases(market_flag)
+    except RuntimeError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        return False
+    if not target_aliases:
+        console.print(
+            f"[red]Error: no DB aliases resolved for market '{market_flag}'[/red]"
+        )
+        return False
+
     # Show what will happen
     console.print()
     info_table = Table(box=box.SIMPLE, show_header=False)
@@ -2175,35 +2304,48 @@ def update_lead_ship_command(
     info_table.add_row("Doctrine", f"{doctrine_info['name']} (ID: {doctrine_id})")
     info_table.add_row("Fit", f"{fit_info['fit_name']} (ID: {fit_id})")
     info_table.add_row("Lead Ship", f"{fit_info['ship_name']} ({fit_info['ship_type_id']})")
-    info_table.add_row("Market DB", db_alias)
+    info_table.add_row("Market", f"{market_flag} ({', '.join(target_aliases)})")
     console.print(info_table)
     console.print()
 
     if not Confirm.ask(
-        f"Set lead ship for doctrine {doctrine_id} to {fit_info['ship_name']}?"
+        f"Set lead ship for doctrine {doctrine_id} to {fit_info['ship_name']} "
+        f"in {', '.join(target_aliases)}?"
     ):
         console.print("[yellow]Cancelled[/yellow]")
         return False
 
-    try:
-        set_lead_ship(
-            doctrine_id=doctrine_id,
-            doctrine_name=doctrine_info["name"],
-            fit_id=fit_id,
-            ship_type_id=fit_info["ship_type_id"],
-            remote=remote,
-            db_alias=db_alias,
-        )
-        console.print(
-            f"[green]✓ Lead ship for doctrine {doctrine_id} set to "
-            f"{fit_info['ship_name']} (fit {fit_id})[/green]"
-        )
-        return True
+    successes = 0
+    failures = 0
+    for alias in target_aliases:
+        db = DatabaseConfig(alias)
+        engine = db.remote_engine if remote else db.engine
+        loc = f"{alias} ({'remote' if remote else 'local'})"
+        try:
+            with engine.begin() as conn:
+                set_lead_ship(
+                    doctrine_id=doctrine_id,
+                    doctrine_name=doctrine_info["name"],
+                    fit_id=fit_id,
+                    ship_type_id=fit_info["ship_type_id"],
+                    conn=conn,
+                )
+            console.print(
+                f"[green]✓ Lead ship for doctrine {doctrine_id} set to "
+                f"{fit_info['ship_name']} (fit {fit_id}) in {loc}[/green]"
+            )
+            successes += 1
+        except (OperationalError, DatabaseError, ConnectionError, TimeoutError) as e:
+            console.print(f"[yellow]Skipped {loc}: {e}[/yellow]")
+            failures += 1
+        except Exception as e:
+            console.print(f"[red]✗ Error in {loc}: {e}[/red]")
+            logger.exception("Error in update_lead_ship_command for %s", loc)
+            failures += 1
+        finally:
+            engine.dispose()
 
-    except Exception as e:
-        console.print(f"[red]✗ Error: {e}[/red]")
-        logger.exception(f"Error in update_lead_ship_command")
-        return False
+    return successes > 0 and failures == 0
 
 
 def doctrine_remove_fit_command(
@@ -2451,7 +2593,7 @@ def doctrine_remove_fit_command(
             # Step 4: Remove from fittings_doctrine_fittings ONLY if the fit
             # is no longer in this doctrine on ANY market database.
             still_in_other_market = False
-            for other_alias in ["wcmkt", "wcmktnorth"]:
+            for other_alias in _configured_market_db_aliases():
                 if other_alias == db_alias:
                     continue
                 other_fits = get_doctrine_fits_from_market(
@@ -2785,7 +2927,7 @@ def fit_update_command(
 
                 # Determine which databases to update
                 if market_flag == "both":
-                    aliases = ["wcmkt", "wcmktnorth"]
+                    aliases = _configured_market_db_aliases()
                 else:
                     aliases = [target_alias]
 
@@ -2879,7 +3021,7 @@ def fit_update_command(
         try:
             # Update all markets where the fit currently exists
             aliases = []
-            for alias in ["wcmkt", "wcmktnorth"]:
+            for alias in _configured_market_db_aliases():
                 existing = get_fit_target(fit_id, remote=use_remote, db_alias=alias)
                 if existing is not None:
                     aliases.append(alias)
@@ -2955,7 +3097,7 @@ def fit_update_command(
         if market_flag in ("both", "primary"):
             # "primary" is the default when no --market flag is passed,
             # so treat it the same as "both" for remove.
-            aliases = ["wcmkt", "wcmktnorth"]
+            aliases = _configured_market_db_aliases()
         else:
             aliases = [target_alias]
         success = True
@@ -3012,8 +3154,8 @@ def fit_update_command(
         return update_lead_ship_command(
             doctrine_id=doctrine_id,
             fit_id=fit_id,
+            market_flag=market_flag,
             remote=use_remote,
-            db_alias=target_alias,
         )
 
     elif subcommand == "update-friendly-name":

--- a/src/mkts_backend/cli_tools/market_args.py
+++ b/src/mkts_backend/cli_tools/market_args.py
@@ -36,6 +36,27 @@ def resolve_market_alias(args: list[str]) -> str | None:
     return None if resolved == _UNSPECIFIED else resolved
 
 
+def resolve_market_alias_interactive(default: str = "primary") -> str:
+    """Prompt the user to pick a market alias when the current choice is ambiguous.
+
+    Returns one of ``primary`` / ``deployment`` / ``both``. In non-TTY
+    sessions returns ``default`` without prompting so scripts keep working.
+    """
+    if not sys.stdin.isatty():
+        return default
+    from rich.console import Console
+    from rich.prompt import Prompt
+
+    console = Console()
+    console.print("\n[yellow]This command needs a specific market — pick one:[/yellow]")
+    console.print("  1) primary")
+    console.print("  2) deployment")
+    console.print("  3) both")
+    default_choice = {"primary": "1", "deployment": "2", "both": "3"}.get(default, "1")
+    choice = Prompt.ask("Choice", choices=["1", "2", "3"], default=default_choice)
+    return {"1": "primary", "2": "deployment", "3": "both"}[choice]
+
+
 def parse_market_args(args: list[str], default: str = "primary") -> str:
     """Scan args for market flags and return a normalized market alias.
 

--- a/src/mkts_backend/utils/doctrine_update.py
+++ b/src/mkts_backend/utils/doctrine_update.py
@@ -22,6 +22,20 @@ def _get_engine(db_alias: str, remote: bool = False):
     return cfg.remote_engine if remote else cfg.engine
 
 
+def _require_single_context(conn, engine) -> None:
+    """Reject callers that pass both a transactional ``conn`` and an ``engine``.
+
+    ``conn`` and ``engine`` are alternative transaction contexts — passing both
+    is always a caller bug (writes would land in whichever branch the helper
+    picks first), so surface it loudly instead of silently choosing one.
+    """
+    if conn is not None and engine is not None:
+        raise ValueError(
+            "Pass either conn= or engine=, not both. They are alternative "
+            "transaction contexts."
+        )
+
+
 doctrines_fields = ['id', 'fit_id', 'ship_id', 'ship_name', 'hulls', 'type_id', 'type_name', 'fit_qty', 'fits_on_mkt', 'total_stock', 'price', 'avg_vol', 'days', 'group_id', 'group_name', 'category_id', 'category_name', 'timestamp']
 
 doctrine_fit_id = 494
@@ -170,6 +184,7 @@ def upsert_doctrine_fits(
             the function participates in the caller's transaction and does
             NOT commit; caller's ``with engine.begin()`` commits on exit.
     """
+    _require_single_context(conn, engine)
     def _do(c):
         existing = c.execute(
             text("SELECT id FROM doctrine_fits WHERE fit_id = :fit_id AND doctrine_id = :doctrine_id"),
@@ -238,7 +253,9 @@ def update_fit_market_flag(
         fit_id: The fit ID to update
         market_flag: New market assignment ('primary', 'deployment', or 'both')
         remote: Whether to use remote database
-        db_alias: Database alias to use
+        db_alias: Database alias to use. When ``conn`` is passed without an
+            explicit ``db_alias``, log attribution uses ``[conn]`` to avoid
+            falsely claiming writes landed on the default catch-all.
         doctrine_id: If provided, only update the row for this doctrine
             (otherwise updates ALL doctrine_fits rows for the fit)
         engine: Optional shared engine (caller manages lifecycle)
@@ -248,6 +265,7 @@ def update_fit_market_flag(
     Returns:
         True if update succeeded, False if fit not found
     """
+    _require_single_context(conn, engine)
     if market_flag not in ("primary", "deployment", "both"):
         raise ValueError(f"Invalid market_flag: {market_flag}. Must be 'primary', 'deployment', or 'both'")
 
@@ -276,7 +294,13 @@ def update_fit_market_flag(
         if engine is None:
             _engine.dispose()
 
-    db_label = f"{db_alias}({'remote' if remote else 'local'})"
+    # When the caller supplied conn= but not an explicit db_alias, we don't
+    # actually know which DB the writes landed on — report [conn] instead of
+    # claiming "wcmkt(local)".
+    if conn is not None and (not db_alias or db_alias == "wcmkt"):
+        db_label = "[conn]"
+    else:
+        db_label = f"{db_alias}({'remote' if remote else 'local'})"
     if rows_affected > 0:
         logger.info(f"[{db_label}] Updated market_flag to '{market_flag}' for fit_id {fit_id} ({rows_affected} rows)")
         return True
@@ -339,6 +363,7 @@ def get_fit_target(fit_id: int, remote: bool = False, db_alias: str = "wcmkt") -
 
 
 def upsert_doctrine_map(doctrine_id: int, fit_id: int, remote: bool = False, db_alias: str = "wcmkt", engine=None, conn=None) -> None:
+    _require_single_context(conn, engine)
     def _do(c):
         exists = c.execute(
             text("SELECT 1 FROM doctrine_map WHERE doctrine_id = :doctrine_id AND fitting_id = :fit_id"),
@@ -380,9 +405,20 @@ def remove_doctrine_fits(
     """
     Remove a fit from the doctrine_fits table.
 
+    Args:
+        doctrine_id: The doctrine containing the fit
+        fit_id: The fit ID to remove
+        remote: Whether to use remote database
+        db_alias: Database alias to use
+        engine: Optional shared engine (caller manages lifecycle)
+        conn: Optional caller-owned transactional connection. When provided,
+            the function participates in the caller's transaction and does
+            NOT commit.
+
     Returns:
         True if a row was deleted, False if no matching row found
     """
+    _require_single_context(conn, engine)
     def _do(c):
         return c.execute(
             text("DELETE FROM doctrine_fits WHERE fit_id = :fit_id AND doctrine_id = :doctrine_id"),
@@ -416,7 +452,22 @@ def remove_doctrine_map(
     engine=None,
     conn=None,
 ) -> bool:
-    """Remove a fit-doctrine mapping from the doctrine_map table."""
+    """Remove a fit-doctrine mapping from the doctrine_map table.
+
+    Args:
+        doctrine_id: The doctrine to unmap from
+        fit_id: The fit ID to unmap
+        remote: Whether to use remote database
+        db_alias: Database alias to use
+        engine: Optional shared engine (caller manages lifecycle)
+        conn: Optional caller-owned transactional connection. When provided,
+            the function participates in the caller's transaction and does
+            NOT commit.
+
+    Returns:
+        True if a row was deleted, False if no matching row found
+    """
+    _require_single_context(conn, engine)
     def _do(c):
         return c.execute(
             text("DELETE FROM doctrine_map WHERE doctrine_id = :doctrine_id AND fitting_id = :fit_id"),
@@ -449,7 +500,21 @@ def remove_ship_target(
     engine=None,
     conn=None,
 ) -> bool:
-    """Remove the ship_targets row for a fit."""
+    """Remove the ship_targets row for a fit.
+
+    Args:
+        fit_id: The fit ID whose ship_targets row should be removed
+        remote: Whether to use remote database
+        db_alias: Database alias to use
+        engine: Optional shared engine (caller manages lifecycle)
+        conn: Optional caller-owned transactional connection. When provided,
+            the function participates in the caller's transaction and does
+            NOT commit.
+
+    Returns:
+        True if a row was deleted, False if no matching row found
+    """
+    _require_single_context(conn, engine)
     def _do(c):
         return c.execute(
             text("DELETE FROM ship_targets WHERE fit_id = :fit_id"),
@@ -542,7 +607,21 @@ def remove_doctrines_for_fit(
     engine=None,
     conn=None,
 ) -> int:
-    """Remove all doctrines table rows for a specific fit."""
+    """Remove all doctrines table rows for a specific fit.
+
+    Args:
+        fit_id: The fit ID whose doctrines rows should be removed
+        remote: Whether to use remote database
+        db_alias: Database alias to use
+        engine: Optional shared engine (caller manages lifecycle)
+        conn: Optional caller-owned transactional connection. When provided,
+            the function participates in the caller's transaction and does
+            NOT commit.
+
+    Returns:
+        Number of rows deleted
+    """
+    _require_single_context(conn, engine)
     def _do(c):
         return c.execute(
             text("DELETE FROM doctrines WHERE fit_id = :fit_id"),
@@ -587,7 +666,25 @@ class DoctrineComponent:
         self.timestamp = datetime.datetime.strftime(datetime.datetime.now(datetime.timezone.utc), '%Y-%m-%d %H:%M:%S')
 
 def upsert_ship_target(fit_id: int, fit_name: str, ship_id: int, ship_name: str, ship_target: int, remote: bool = False, db_alias: str = "wcmkt", engine=None, conn=None) -> bool:
-    """Upsert ship_targets entry keyed by fit_id."""
+    """Upsert ship_targets entry keyed by fit_id.
+
+    Args:
+        fit_id: Fit ID (primary key in ship_targets)
+        fit_name: Fit name
+        ship_id: Ship type ID
+        ship_name: Ship name
+        ship_target: Target quantity for the fit
+        remote: Whether to use remote database
+        db_alias: Database alias to use
+        engine: Optional shared engine (caller manages lifecycle)
+        conn: Optional caller-owned transactional connection. When provided,
+            the function participates in the caller's transaction and does
+            NOT commit.
+
+    Returns:
+        True (operation is always considered successful on no exception)
+    """
+    _require_single_context(conn, engine)
     created_at = datetime.datetime.strftime(datetime.datetime.now(datetime.timezone.utc), '%Y-%m-%d %H:%M:%S')
 
     def _do(c):
@@ -753,9 +850,22 @@ def upsert_lead_ship(
     The lead ship is the primary/representative ship for a doctrine,
     set to the first fit added.
 
+    Args:
+        doctrine_id: The doctrine to assign a lead ship to
+        doctrine_name: The doctrine's friendly name (copied into the row)
+        fit_id: The fit to adopt as lead ship
+        ship_type_id: The fit's ship type ID
+        remote: Whether to use remote database
+        db_alias: Database alias to use
+        engine: Optional shared engine (caller manages lifecycle)
+        conn: Optional caller-owned transactional connection. When provided,
+            the function participates in the caller's transaction and does
+            NOT commit. A no-op (when a row already exists) also skips commit.
+
     Returns:
         True if a row was inserted, False if one already exists
     """
+    _require_single_context(conn, engine)
     def _do(c) -> bool:
         if lead_ship_exists(doctrine_id, c):
             logger.info(f"lead_ships already has entry for doctrine_id {doctrine_id}, skipping")
@@ -805,9 +915,22 @@ def set_lead_ship(
     Unlike upsert_lead_ship (which only inserts if missing), this
     always overwrites an existing row.
 
+    Args:
+        doctrine_id: The doctrine whose lead ship is being set
+        doctrine_name: The doctrine's friendly name (copied into the row)
+        fit_id: The fit to make lead ship
+        ship_type_id: The fit's ship type ID
+        remote: Whether to use remote database
+        db_alias: Database alias to use
+        engine: Optional shared engine (caller manages lifecycle)
+        conn: Optional caller-owned transactional connection. When provided,
+            the function participates in the caller's transaction and does
+            NOT commit.
+
     Returns:
         True on success
     """
+    _require_single_context(conn, engine)
     def _do(c):
         c.execute(
             text("DELETE FROM lead_ships WHERE doctrine_id = :doctrine_id"),
@@ -941,6 +1064,7 @@ def refresh_doctrines_for_fit(fit_id: int, ship_id: int, ship_name: str, remote:
     When ``conn`` is provided, uses it for all reads/writes on the market DB
     (single transaction) and does not commit — caller's engine.begin() owns commit.
     """
+    _require_single_context(conn, engine)
     # Aggregate component quantities from fittings (separate DB; always own engine)
     fittings_engine = _get_engine("fittings", remote)
     try:

--- a/src/mkts_backend/utils/doctrine_update.py
+++ b/src/mkts_backend/utils/doctrine_update.py
@@ -155,6 +155,7 @@ def upsert_doctrine_fits(
     db_alias: str = "wcmkt",
     market_flag: str = "primary",
     engine=None,
+    conn=None,
 ) -> None:
     """
     Upsert doctrine_fits entry keyed by (doctrine_id, fit_id).
@@ -165,10 +166,12 @@ def upsert_doctrine_fits(
         db_alias: Database alias to use
         market_flag: Market assignment ('primary', 'deployment', or 'both')
         engine: Optional shared engine (caller manages lifecycle)
+        conn: Optional caller-owned transactional connection. When provided,
+            the function participates in the caller's transaction and does
+            NOT commit; caller's ``with engine.begin()`` commits on exit.
     """
-    _engine = engine or _get_engine(db_alias, remote)
-    with _engine.connect() as conn:
-        existing = conn.execute(
+    def _do(c):
+        existing = c.execute(
             text("SELECT id FROM doctrine_fits WHERE fit_id = :fit_id AND doctrine_id = :doctrine_id"),
             {"fit_id": doctrine_fit.fit_id, "doctrine_id": doctrine_fit.doctrine_id},
         ).fetchone()
@@ -193,7 +196,7 @@ def upsert_doctrine_fits(
                 VALUES (:doctrine_name, :fit_name, :ship_type_id, :doctrine_id, :fit_id, :ship_name, :target, :market_flag)
                 """
             )
-        conn.execute(
+        c.execute(
             stmt,
             {
                 "doctrine_name": doctrine_fit.doctrine_name,
@@ -206,9 +209,16 @@ def upsert_doctrine_fits(
                 "market_flag": market_flag,
             },
         )
-        conn.commit()
-    if engine is None:
-        _engine.dispose()
+
+    if conn is not None:
+        _do(conn)
+    else:
+        _engine = engine or _get_engine(db_alias, remote)
+        with _engine.connect() as c:
+            _do(c)
+            c.commit()
+        if engine is None:
+            _engine.dispose()
     logger.info(f"Upserted doctrine_fits for fit_id {doctrine_fit.fit_id} with market_flag={market_flag}")
 
 
@@ -218,6 +228,8 @@ def update_fit_market_flag(
     remote: bool = False,
     db_alias: str = "wcmkt",
     doctrine_id: int | None = None,
+    engine=None,
+    conn=None,
 ) -> bool:
     """
     Update the market_flag for a fit.
@@ -229,6 +241,9 @@ def update_fit_market_flag(
         db_alias: Database alias to use
         doctrine_id: If provided, only update the row for this doctrine
             (otherwise updates ALL doctrine_fits rows for the fit)
+        engine: Optional shared engine (caller manages lifecycle)
+        conn: Optional caller-owned transactional connection; when provided,
+            no internal commit occurs — caller's transaction owns it.
 
     Returns:
         True if update succeeded, False if fit not found
@@ -236,25 +251,30 @@ def update_fit_market_flag(
     if market_flag not in ("primary", "deployment", "both"):
         raise ValueError(f"Invalid market_flag: {market_flag}. Must be 'primary', 'deployment', or 'both'")
 
-    engine = _get_engine(db_alias, remote)
-    with engine.connect() as conn:
+    def _do(c):
         if doctrine_id is not None:
-            result = conn.execute(
+            return c.execute(
                 text(
                     "UPDATE doctrine_fits SET market_flag = :market_flag "
                     "WHERE fit_id = :fit_id AND doctrine_id = :doctrine_id"
                 ),
                 {"fit_id": fit_id, "market_flag": market_flag, "doctrine_id": doctrine_id},
             )
-        else:
-            result = conn.execute(
-                text("UPDATE doctrine_fits SET market_flag = :market_flag WHERE fit_id = :fit_id"),
-                {"fit_id": fit_id, "market_flag": market_flag},
-            )
-        conn.commit()
-        rows_affected = result.rowcount
+        return c.execute(
+            text("UPDATE doctrine_fits SET market_flag = :market_flag WHERE fit_id = :fit_id"),
+            {"fit_id": fit_id, "market_flag": market_flag},
+        )
 
-    engine.dispose()
+    if conn is not None:
+        rows_affected = _do(conn).rowcount
+    else:
+        _engine = engine or _get_engine(db_alias, remote)
+        with _engine.connect() as c:
+            result = _do(c)
+            c.commit()
+            rows_affected = result.rowcount
+        if engine is None:
+            _engine.dispose()
 
     db_label = f"{db_alias}({'remote' if remote else 'local'})"
     if rows_affected > 0:
@@ -318,26 +338,32 @@ def get_fit_target(fit_id: int, remote: bool = False, db_alias: str = "wcmkt") -
     return None
 
 
-def upsert_doctrine_map(doctrine_id: int, fit_id: int, remote: bool = False, db_alias: str = "wcmkt", engine=None) -> None:
+def upsert_doctrine_map(doctrine_id: int, fit_id: int, remote: bool = False, db_alias: str = "wcmkt", engine=None, conn=None) -> None:
+    def _do(c):
+        exists = c.execute(
+            text("SELECT 1 FROM doctrine_map WHERE doctrine_id = :doctrine_id AND fitting_id = :fit_id"),
+            {"doctrine_id": doctrine_id, "fit_id": fit_id},
+        ).fetchone()
+        if exists:
+            logger.info(f"doctrine_map already present for doctrine_id={doctrine_id}, fit_id={fit_id}")
+            return
+        next_id = c.execute(
+            text("SELECT COALESCE(MAX(id), 0) + 1 AS next_id FROM doctrine_map")
+        ).scalar_one()
+        c.execute(
+            text("INSERT INTO doctrine_map (id, doctrine_id, fitting_id) VALUES (:id, :doctrine_id, :fit_id)"),
+            {"id": next_id, "doctrine_id": doctrine_id, "fit_id": fit_id},
+        )
+        logger.info(f"Upserted doctrine_map entry doctrine_id={doctrine_id}, fit_id={fit_id}")
+
+    if conn is not None:
+        _do(conn)
+        return
     _engine = engine or _get_engine(db_alias, remote)
     try:
-        with _engine.connect() as conn:
-            exists = conn.execute(
-                text("SELECT 1 FROM doctrine_map WHERE doctrine_id = :doctrine_id AND fitting_id = :fit_id"),
-                {"doctrine_id": doctrine_id, "fit_id": fit_id},
-            ).fetchone()
-            if exists:
-                logger.info(f"doctrine_map already present for doctrine_id={doctrine_id}, fit_id={fit_id}")
-                return
-            next_id = conn.execute(
-                text("SELECT COALESCE(MAX(id), 0) + 1 AS next_id FROM doctrine_map")
-            ).scalar_one()
-            conn.execute(
-                text("INSERT INTO doctrine_map (id, doctrine_id, fitting_id) VALUES (:id, :doctrine_id, :fit_id)"),
-                {"id": next_id, "doctrine_id": doctrine_id, "fit_id": fit_id},
-            )
-            conn.commit()
-            logger.info(f"Upserted doctrine_map entry doctrine_id={doctrine_id}, fit_id={fit_id}")
+        with _engine.connect() as c:
+            _do(c)
+            c.commit()
     finally:
         if engine is None:
             _engine.dispose()
@@ -349,30 +375,30 @@ def remove_doctrine_fits(
     remote: bool = False,
     db_alias: str = "wcmkt",
     engine=None,
+    conn=None,
 ) -> bool:
     """
     Remove a fit from the doctrine_fits table.
 
-    Args:
-        doctrine_id: The doctrine ID
-        fit_id: The fit ID to remove
-        remote: Whether to use remote database
-        db_alias: Database alias to use
-        engine: Optional shared engine (caller manages lifecycle)
-
     Returns:
         True if a row was deleted, False if no matching row found
     """
-    _engine = engine or _get_engine(db_alias, remote)
-    with _engine.connect() as conn:
-        result = conn.execute(
+    def _do(c):
+        return c.execute(
             text("DELETE FROM doctrine_fits WHERE fit_id = :fit_id AND doctrine_id = :doctrine_id"),
             {"fit_id": fit_id, "doctrine_id": doctrine_id},
         )
-        conn.commit()
-        rows_affected = result.rowcount
-    if engine is None:
-        _engine.dispose()
+
+    if conn is not None:
+        rows_affected = _do(conn).rowcount
+    else:
+        _engine = engine or _get_engine(db_alias, remote)
+        with _engine.connect() as c:
+            result = _do(c)
+            c.commit()
+            rows_affected = result.rowcount
+        if engine is None:
+            _engine.dispose()
 
     if rows_affected > 0:
         logger.info(f"Removed fit_id {fit_id} from doctrine_id {doctrine_id} in doctrine_fits ({rows_affected} rows)")
@@ -388,30 +414,25 @@ def remove_doctrine_map(
     remote: bool = False,
     db_alias: str = "wcmkt",
     engine=None,
+    conn=None,
 ) -> bool:
-    """
-    Remove a fit-doctrine mapping from the doctrine_map table.
-
-    Args:
-        doctrine_id: The doctrine ID
-        fit_id: The fit ID (fitting_id in doctrine_map)
-        remote: Whether to use remote database
-        db_alias: Database alias to use
-        engine: Optional shared engine (caller manages lifecycle)
-
-    Returns:
-        True if a row was deleted, False if no matching row found
-    """
-    _engine = engine or _get_engine(db_alias, remote)
-    with _engine.connect() as conn:
-        result = conn.execute(
+    """Remove a fit-doctrine mapping from the doctrine_map table."""
+    def _do(c):
+        return c.execute(
             text("DELETE FROM doctrine_map WHERE doctrine_id = :doctrine_id AND fitting_id = :fit_id"),
             {"doctrine_id": doctrine_id, "fit_id": fit_id},
         )
-        conn.commit()
-        rows_affected = result.rowcount
-    if engine is None:
-        _engine.dispose()
+
+    if conn is not None:
+        rows_affected = _do(conn).rowcount
+    else:
+        _engine = engine or _get_engine(db_alias, remote)
+        with _engine.connect() as c:
+            result = _do(c)
+            c.commit()
+            rows_affected = result.rowcount
+        if engine is None:
+            _engine.dispose()
 
     if rows_affected > 0:
         logger.info(f"Removed doctrine_map entry for doctrine_id={doctrine_id}, fit_id={fit_id}")
@@ -426,29 +447,25 @@ def remove_ship_target(
     remote: bool = False,
     db_alias: str = "wcmkt",
     engine=None,
+    conn=None,
 ) -> bool:
-    """
-    Remove the ship_targets row for a fit.
-
-    Args:
-        fit_id: The fit ID to remove
-        remote: Whether to use remote database
-        db_alias: Database alias to use
-        engine: Optional shared engine (caller manages lifecycle)
-
-    Returns:
-        True if a row was deleted, False if no matching row found
-    """
-    _engine = engine or _get_engine(db_alias, remote)
-    with _engine.connect() as conn:
-        result = conn.execute(
+    """Remove the ship_targets row for a fit."""
+    def _do(c):
+        return c.execute(
             text("DELETE FROM ship_targets WHERE fit_id = :fit_id"),
             {"fit_id": fit_id},
         )
-        conn.commit()
-        rows_affected = result.rowcount
-    if engine is None:
-        _engine.dispose()
+
+    if conn is not None:
+        rows_affected = _do(conn).rowcount
+    else:
+        _engine = engine or _get_engine(db_alias, remote)
+        with _engine.connect() as c:
+            result = _do(c)
+            c.commit()
+            rows_affected = result.rowcount
+        if engine is None:
+            _engine.dispose()
 
     if rows_affected > 0:
         logger.info(f"Removed ship_targets row for fit_id {fit_id} ({db_alias})")
@@ -523,29 +540,25 @@ def remove_doctrines_for_fit(
     remote: bool = False,
     db_alias: str = "wcmkt",
     engine=None,
+    conn=None,
 ) -> int:
-    """
-    Remove all doctrines table rows for a specific fit.
-
-    Args:
-        fit_id: The fit ID to remove rows for
-        remote: Whether to use remote database
-        db_alias: Database alias to use
-        engine: Optional shared engine (caller manages lifecycle)
-
-    Returns:
-        Number of rows deleted
-    """
-    _engine = engine or _get_engine(db_alias, remote)
-    with _engine.connect() as conn:
-        result = conn.execute(
+    """Remove all doctrines table rows for a specific fit."""
+    def _do(c):
+        return c.execute(
             text("DELETE FROM doctrines WHERE fit_id = :fit_id"),
             {"fit_id": fit_id},
         )
-        conn.commit()
-        rows_affected = result.rowcount
-    if engine is None:
-        _engine.dispose()
+
+    if conn is not None:
+        rows_affected = _do(conn).rowcount
+    else:
+        _engine = engine or _get_engine(db_alias, remote)
+        with _engine.connect() as c:
+            result = _do(c)
+            c.commit()
+            rows_affected = result.rowcount
+        if engine is None:
+            _engine.dispose()
 
     logger.info(f"Removed {rows_affected} rows from doctrines table for fit_id {fit_id}")
     return rows_affected
@@ -573,23 +586,20 @@ class DoctrineComponent:
     def __post_init__(self):
         self.timestamp = datetime.datetime.strftime(datetime.datetime.now(datetime.timezone.utc), '%Y-%m-%d %H:%M:%S')
 
-def upsert_ship_target(fit_id: int, fit_name: str, ship_id: int, ship_name: str, ship_target: int, remote: bool = False, db_alias: str = "wcmkt", engine=None) -> bool:
-    """
-    Upsert ship_targets entry keyed by fit_id.
-    """
+def upsert_ship_target(fit_id: int, fit_name: str, ship_id: int, ship_name: str, ship_target: int, remote: bool = False, db_alias: str = "wcmkt", engine=None, conn=None) -> bool:
+    """Upsert ship_targets entry keyed by fit_id."""
     created_at = datetime.datetime.strftime(datetime.datetime.now(datetime.timezone.utc), '%Y-%m-%d %H:%M:%S')
-    _engine = engine or _get_engine(db_alias, remote)
-    with _engine.connect() as conn:
+
+    def _do(c):
         # Some schemas (e.g., wcmktnorth2) lack PK/unique constraint on fit_id; use delete-then-insert.
-        conn.execute(text("DELETE FROM ship_targets WHERE fit_id = :fit_id"), {"fit_id": fit_id})
-        insert_stmt = text(
-            """
-            INSERT INTO ship_targets (fit_id, fit_name, ship_id, ship_name, ship_target, created_at)
-            VALUES (:fit_id, :fit_name, :ship_id, :ship_name, :ship_target, :created_at)
-            """
-        )
-        conn.execute(
-            insert_stmt,
+        c.execute(text("DELETE FROM ship_targets WHERE fit_id = :fit_id"), {"fit_id": fit_id})
+        c.execute(
+            text(
+                """
+                INSERT INTO ship_targets (fit_id, fit_name, ship_id, ship_name, ship_target, created_at)
+                VALUES (:fit_id, :fit_name, :ship_id, :ship_name, :ship_target, :created_at)
+                """
+            ),
             {
                 "fit_id": fit_id,
                 "fit_name": fit_name,
@@ -599,9 +609,16 @@ def upsert_ship_target(fit_id: int, fit_name: str, ship_id: int, ship_name: str,
                 "created_at": created_at,
             },
         )
-        conn.commit()
-    if engine is None:
-        _engine.dispose()
+
+    if conn is not None:
+        _do(conn)
+    else:
+        _engine = engine or _get_engine(db_alias, remote)
+        with _engine.connect() as c:
+            _do(c)
+            c.commit()
+        if engine is None:
+            _engine.dispose()
     logger.info(f"Upserted ship_targets for fit_id {fit_id}")
     return True
 
@@ -711,6 +728,15 @@ def add_fit_to_doctrines_table(DoctrineFit: DoctrineFitItems):
     conn.close()
     engine.dispose()
 
+def lead_ship_exists(doctrine_id: int, conn) -> bool:
+    """Return True if a lead_ships row already exists for doctrine_id on conn."""
+    row = conn.execute(
+        text("SELECT 1 FROM lead_ships WHERE doctrine_id = :doctrine_id"),
+        {"doctrine_id": doctrine_id},
+    ).fetchone()
+    return row is not None
+
+
 def upsert_lead_ship(
     doctrine_id: int,
     doctrine_name: str,
@@ -718,6 +744,8 @@ def upsert_lead_ship(
     ship_type_id: int,
     remote: bool = False,
     db_alias: str = "wcmkt",
+    engine=None,
+    conn=None,
 ) -> bool:
     """
     Insert a lead_ships row for a doctrine if one doesn't already exist.
@@ -725,42 +753,37 @@ def upsert_lead_ship(
     The lead ship is the primary/representative ship for a doctrine,
     set to the first fit added.
 
-    Args:
-        doctrine_id: The doctrine ID
-        doctrine_name: The doctrine name
-        fit_id: The fit ID to set as lead
-        ship_type_id: The ship type ID (lead_ship column)
-        remote: Whether to use remote database
-        db_alias: Database alias to use
-
     Returns:
         True if a row was inserted, False if one already exists
     """
-    engine = _get_engine(db_alias, remote)
-    inserted = False
-    with engine.connect() as conn:
-        existing = conn.execute(
-            text("SELECT 1 FROM lead_ships WHERE doctrine_id = :doctrine_id"),
-            {"doctrine_id": doctrine_id},
-        ).fetchone()
-        if existing:
+    def _do(c) -> bool:
+        if lead_ship_exists(doctrine_id, c):
             logger.info(f"lead_ships already has entry for doctrine_id {doctrine_id}, skipping")
-        else:
-            conn.execute(
-                text(
-                    "INSERT INTO lead_ships (doctrine_name, doctrine_id, lead_ship, fit_id) "
-                    "VALUES (:doctrine_name, :doctrine_id, :lead_ship, :fit_id)"
-                ),
-                {
-                    "doctrine_name": doctrine_name,
-                    "doctrine_id": doctrine_id,
-                    "lead_ship": ship_type_id,
-                    "fit_id": fit_id,
-                },
-            )
-            conn.commit()
-            inserted = True
-    engine.dispose()
+            return False
+        c.execute(
+            text(
+                "INSERT INTO lead_ships (doctrine_name, doctrine_id, lead_ship, fit_id) "
+                "VALUES (:doctrine_name, :doctrine_id, :lead_ship, :fit_id)"
+            ),
+            {
+                "doctrine_name": doctrine_name,
+                "doctrine_id": doctrine_id,
+                "lead_ship": ship_type_id,
+                "fit_id": fit_id,
+            },
+        )
+        return True
+
+    if conn is not None:
+        inserted = _do(conn)
+    else:
+        _engine = engine or _get_engine(db_alias, remote)
+        with _engine.connect() as c:
+            inserted = _do(c)
+            if inserted:
+                c.commit()
+        if engine is None:
+            _engine.dispose()
     if inserted:
         logger.info(f"Added lead_ship for doctrine_id {doctrine_id}: fit_id={fit_id}, ship={ship_type_id}")
     return inserted
@@ -773,6 +796,8 @@ def set_lead_ship(
     ship_type_id: int,
     remote: bool = False,
     db_alias: str = "wcmkt",
+    engine=None,
+    conn=None,
 ) -> bool:
     """
     Set or replace the lead ship for a doctrine.
@@ -780,25 +805,15 @@ def set_lead_ship(
     Unlike upsert_lead_ship (which only inserts if missing), this
     always overwrites an existing row.
 
-    Args:
-        doctrine_id: The doctrine ID
-        doctrine_name: The doctrine name
-        fit_id: The fit ID to set as lead
-        ship_type_id: The ship type ID (lead_ship column)
-        remote: Whether to use remote database
-        db_alias: Database alias to use
-
     Returns:
         True on success
     """
-    engine = _get_engine(db_alias, remote)
-    with engine.connect() as conn:
-        # Delete any existing row, then insert fresh
-        conn.execute(
+    def _do(c):
+        c.execute(
             text("DELETE FROM lead_ships WHERE doctrine_id = :doctrine_id"),
             {"doctrine_id": doctrine_id},
         )
-        conn.execute(
+        c.execute(
             text(
                 "INSERT INTO lead_ships (doctrine_name, doctrine_id, lead_ship, fit_id) "
                 "VALUES (:doctrine_name, :doctrine_id, :lead_ship, :fit_id)"
@@ -810,8 +825,16 @@ def set_lead_ship(
                 "fit_id": fit_id,
             },
         )
-        conn.commit()
-    engine.dispose()
+
+    if conn is not None:
+        _do(conn)
+    else:
+        _engine = engine or _get_engine(db_alias, remote)
+        with _engine.connect() as c:
+            _do(c)
+            c.commit()
+        if engine is None:
+            _engine.dispose()
     logger.info(f"Set lead_ship for doctrine_id {doctrine_id}: fit_id={fit_id}, ship={ship_type_id}")
     return True
 
@@ -911,99 +934,103 @@ def add_doctrine_type_info_to_watchlist(doctrine_id: int):
         logger.info(f"Added {type_info.type_name} to watchlist")
         print(f"Added {type_info.type_name} to watchlist")
 
-def refresh_doctrines_for_fit(fit_id: int, ship_id: int, ship_name: str, remote: bool = False, db_alias: str = "wcmkt", engine=None) -> None:
+def refresh_doctrines_for_fit(fit_id: int, ship_id: int, ship_name: str, remote: bool = False, db_alias: str = "wcmkt", engine=None, conn=None) -> None:
     """
     Rebuild doctrines table rows for a fit based on fittings_fittingitem content.
+
+    When ``conn`` is provided, uses it for all reads/writes on the market DB
+    (single transaction) and does not commit — caller's engine.begin() owns commit.
     """
-    # Aggregate component quantities from fittings
+    # Aggregate component quantities from fittings (separate DB; always own engine)
     fittings_engine = _get_engine("fittings", remote)
     try:
-        with fittings_engine.connect() as conn:
-            rows = conn.execute(
+        with fittings_engine.connect() as fconn:
+            rows = fconn.execute(
                 text(
                     "SELECT type_id, SUM(quantity) as qty FROM fittings_fittingitem WHERE fit_id = :fit_id GROUP BY type_id"
                 ),
                 {"fit_id": fit_id},
             ).fetchall()
-
         components = [(row.type_id, row.qty) for row in rows]
-        # Ensure hull present (qty 1)
         if ship_id not in [c[0] for c in components]:
             components.append((ship_id, 1))
     finally:
         fittings_engine.dispose()
 
-    _engine = engine or _get_engine(db_alias, remote)
-    try:
-        timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat()
 
-        # Pull market stats once into dict for quick lookup
+    def _do(c):
         stats_map = {}
-        with _engine.connect() as conn:
-            stats_rows = conn.execute(
-                text(
-                    "SELECT type_id, price, avg_price, avg_volume, days_remaining, total_volume_remain FROM marketstats"
-                )
-            ).fetchall()
-            for r in stats_rows:
-                stats_map[r.type_id] = r
+        stats_rows = c.execute(
+            text(
+                "SELECT type_id, price, avg_price, avg_volume, days_remaining, total_volume_remain FROM marketstats"
+            )
+        ).fetchall()
+        for r in stats_rows:
+            stats_map[r.type_id] = r
 
         hull_stats = stats_map.get(ship_id)
         hull_stock = int(hull_stats.total_volume_remain) if hull_stats and hull_stats.total_volume_remain is not None else 0
 
-        with _engine.connect() as conn:
-            conn.execute(text("DELETE FROM doctrines WHERE fit_id = :fit_id"), {"fit_id": fit_id})
-            insert_stmt = text(
-                """
-                INSERT INTO doctrines (
-                    fit_id, ship_id, ship_name, type_id, type_name, fit_qty, hulls,
-                    fits_on_mkt, total_stock, price, avg_vol, days,
-                    group_id, group_name, category_id, category_name, timestamp
-                ) VALUES (
-                    :fit_id, :ship_id, :ship_name, :type_id, :type_name, :fit_qty, :hulls,
-                    :fits_on_mkt, :total_stock, :price, :avg_vol, :days,
-                    :group_id, :group_name, :category_id, :category_name, :timestamp
-                )
-                """
+        c.execute(text("DELETE FROM doctrines WHERE fit_id = :fit_id"), {"fit_id": fit_id})
+        insert_stmt = text(
+            """
+            INSERT INTO doctrines (
+                fit_id, ship_id, ship_name, type_id, type_name, fit_qty, hulls,
+                fits_on_mkt, total_stock, price, avg_vol, days,
+                group_id, group_name, category_id, category_name, timestamp
+            ) VALUES (
+                :fit_id, :ship_id, :ship_name, :type_id, :type_name, :fit_qty, :hulls,
+                :fits_on_mkt, :total_stock, :price, :avg_vol, :days,
+                :group_id, :group_name, :category_id, :category_name, :timestamp
             )
-            for type_id, qty in components:
-                type_info = TypeInfo(type_id)
-                stats = stats_map.get(type_id)
-                total_stock = int(stats.total_volume_remain) if stats and stats.total_volume_remain is not None else 0
-                price_val = float(stats.price) if stats and stats.price is not None else 0.0
-                avg_vol = float(stats.avg_volume) if stats and stats.avg_volume is not None else 0.0
-                days_rem = float(stats.days_remaining) if stats and stats.days_remaining is not None else 0.0
-                fits_on_mkt = (total_stock / qty) if qty else 0
-                # Set hulls for all rows based on the hull's total_volume_remain
-                hulls = hull_stock
+            """
+        )
+        for type_id, qty in components:
+            type_info = TypeInfo(type_id)
+            stats = stats_map.get(type_id)
+            total_stock = int(stats.total_volume_remain) if stats and stats.total_volume_remain is not None else 0
+            price_val = float(stats.price) if stats and stats.price is not None else 0.0
+            avg_vol = float(stats.avg_volume) if stats and stats.avg_volume is not None else 0.0
+            days_rem = float(stats.days_remaining) if stats and stats.days_remaining is not None else 0.0
+            fits_on_mkt = (total_stock / qty) if qty else 0
+            hulls = hull_stock
 
-                if stats is None:
-                    logger.warning(f"No marketstats for type_id {type_id}; defaulting price/stock to 0")
+            if stats is None:
+                logger.warning(f"No marketstats for type_id {type_id}; defaulting price/stock to 0")
 
-                conn.execute(
-                    insert_stmt,
-                    {
-                        "fit_id": fit_id,
-                        "ship_id": ship_id,
-                        "ship_name": ship_name,
-                        "type_id": type_id,
-                        "type_name": type_info.type_name,
-                        "fit_qty": int(qty),
-                        "hulls": hulls,
-                        "fits_on_mkt": fits_on_mkt,
-                        "total_stock": total_stock,
-                        "price": price_val,
-                        "avg_vol": avg_vol,
-                        "days": days_rem,
-                        "group_id": int(type_info.group_id),
-                        "group_name": type_info.group_name,
-                        "category_id": int(type_info.category_id),
-                        "category_name": type_info.category_name,
-                        "timestamp": timestamp,
-                    },
-                )
-            conn.commit()
+            c.execute(
+                insert_stmt,
+                {
+                    "fit_id": fit_id,
+                    "ship_id": ship_id,
+                    "ship_name": ship_name,
+                    "type_id": type_id,
+                    "type_name": type_info.type_name,
+                    "fit_qty": int(qty),
+                    "hulls": hulls,
+                    "fits_on_mkt": fits_on_mkt,
+                    "total_stock": total_stock,
+                    "price": price_val,
+                    "avg_vol": avg_vol,
+                    "days": days_rem,
+                    "group_id": int(type_info.group_id),
+                    "group_name": type_info.group_name,
+                    "category_id": int(type_info.category_id),
+                    "category_name": type_info.category_name,
+                    "timestamp": timestamp,
+                },
+            )
         logger.info(f"Rebuilt doctrines rows for fit_id {fit_id} ({len(components)} components)")
+
+    if conn is not None:
+        _do(conn)
+        return
+    _engine = engine or _get_engine(db_alias, remote)
+    try:
+        with _engine.connect() as c:
+            _do(c)
+            c.commit()
     finally:
         if engine is None:
             _engine.dispose()

--- a/tests/test_pr27_fixes.py
+++ b/tests/test_pr27_fixes.py
@@ -1,0 +1,97 @@
+"""Regression locks for fixes landed in PR #27 (fit-update cleanup).
+
+These tests cover contracts introduced by the fix round:
+- ``_require_single_context`` rejects simultaneous conn= + engine=
+- ``_execute_market_plan`` aborts cleanly when no markets are configured
+- ``_handle_fit_update`` defaults to 'primary' and warns in non-TTY sessions
+"""
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from mkts_backend.cli_tools import fit_update
+from mkts_backend.utils.doctrine_update import _require_single_context
+
+
+class TestRequireSingleContext:
+    def test_raises_when_both_conn_and_engine_non_none(self):
+        with pytest.raises(ValueError, match="conn= or engine="):
+            _require_single_context(conn=object(), engine=object())
+
+    def test_accepts_neither(self):
+        _require_single_context(conn=None, engine=None)
+
+    def test_accepts_conn_only(self):
+        _require_single_context(conn=object(), engine=None)
+
+    def test_accepts_engine_only(self):
+        _require_single_context(conn=None, engine=object())
+
+
+class TestExecuteMarketPlanZeroAliasGuard:
+    def test_aborts_with_skipped_count_when_no_markets_configured(self, capsys):
+        plans = [
+            {"fit_id": 1, "doctrine_id": 10, "action": "update",
+             "market_flag": "primary", "new_flag": "both"},
+            {"fit_id": 2, "doctrine_id": 10, "action": "remove"},
+        ]
+        with patch.object(fit_update, "_configured_market_db_aliases", return_value=[]):
+            result = fit_update._execute_market_plan(plans, remote=False, db_alias="wcmkt")
+        assert result == {"updated": 0, "deleted": 0, "skipped": 2, "step_failures": 0}
+        captured = capsys.readouterr().out
+        assert "no markets configured" in captured.lower()
+
+    def test_empty_plan_list_still_returns_counters_shape(self):
+        with patch.object(fit_update, "_configured_market_db_aliases", return_value=[]):
+            result = fit_update._execute_market_plan([], remote=False, db_alias="wcmkt")
+        assert result == {"updated": 0, "deleted": 0, "skipped": 0, "step_failures": 0}
+
+
+class TestFitUpdateDispatcherNonTtyFallback:
+    """Cover the command_registry._handle_fit_update non-TTY branch.
+
+    In non-TTY with no --market flag, the handler must default to 'primary'
+    and emit a warning rather than silently picking a DB (which was the
+    pre-fix behavior that motivated PR #27's dispatcher rewrite).
+    """
+
+    def _handler(self):
+        from mkts_backend.cli_tools.command_registry import get_registry
+        entry = get_registry().resolve("fit-update")
+        assert entry is not None
+        return entry.handler
+
+    def test_non_tty_no_market_flag_defaults_to_primary_and_warns(self, caplog):
+        handler = self._handler()
+        captured_kwargs: dict = {}
+
+        def fake_fit_update_command(**kwargs):
+            captured_kwargs.update(kwargs)
+            return True
+
+        with patch("sys.stdin.isatty", return_value=False), \
+             patch("mkts_backend.cli_tools.fit_update.fit_update_command",
+                   side_effect=fake_fit_update_command), \
+             caplog.at_level("WARNING"):
+            # args simulate: `mkts-backend fit-update list-fits` with no --market
+            result = handler(["fit-update", "list-fits"], "primary")
+
+        assert result is True
+        assert captured_kwargs.get("market_flag") == "primary"
+        assert any("non-TTY" in rec.message for rec in caplog.records), \
+            f"expected non-TTY warning, got: {[r.message for r in caplog.records]}"
+
+    def test_explicit_market_both_is_preserved_through_dispatcher(self):
+        """Regression lock for the C-1 fix: --market=both must not collapse to primary."""
+        handler = self._handler()
+        captured_kwargs: dict = {}
+
+        def fake_fit_update_command(**kwargs):
+            captured_kwargs.update(kwargs)
+            return True
+
+        with patch("mkts_backend.cli_tools.fit_update.fit_update_command",
+                   side_effect=fake_fit_update_command):
+            handler(["fit-update", "list-fits", "--market=both"], "both")
+
+        assert captured_kwargs.get("market_flag") == "both"


### PR DESCRIPTION
## Summary

Fixes the four issues tracked in [cli-tool-fixes.md](../blob/main/cli-tool-fixes.md).

- **DB batching** — `_execute_market_plan` now groups every write by `(is_remote, alias)` and runs one `engine.begin()` transaction per bucket. A 20-fit "assign whole doctrine" run to both markets uses ≤ 4 engines total (2 local + 2 remote) instead of hundreds. The per-write HTTP round-trips that were timing out on Turso remotes are gone.
- **`ship_targets` gap** — `assign-market` and `doctrine-add-fit` now provision `ship_targets` up-front via the shared `_provision_fit_in_market` helper instead of relying on the post-hoc heal path.
- **Lead-ship gap** — same helper also writes `lead_ships` idempotently (adopts the first fit added to a new doctrine, never overwrites an explicit user pick via `update-lead-ship`). `_needs_provisioning` learned a fourth check so the heal path retroactively fixes existing doctrines missing a `lead_ships` row.
- **`update-lead-ship` CLI bugs** — signature now takes `market_flag`, resolves target DB aliases via `_configured_market_db_aliases()`, and supports `--market=both`. Dropped the deprecated `db_alias="wcmkt"` default.

Two knock-on cleanups:

- Every hard-coded `["wcmkt", "wcmktnorth"]` list swapped for `_configured_market_db_aliases()` (config-driven, picks up new markets from `settings.toml` automatically).
- `command_registry._handle_fit_update` dropped its `"wcmkt"` fallback; when `--market=both` is ambiguous for a single-DB subcommand, it now prompts with a Rich menu (via new `resolve_market_alias_interactive`) instead of silently defaulting. Non-TTY sessions keep the `primary` default so scripts stay working.

Not in this PR (documented for follow-up):

- [`docs/market_db_map_deferred.md`](docs/market_db_map_deferred.md) — `MARKET_DB_MAP["primary"] = "wcmkt"` mapping, why it's still in place, and the concrete steps for the full fix.
- [`docs/fit_update_simplification_followup.md`](docs/fit_update_simplification_followup.md) — `interactive_add_fit` still has its own provisioning path that could be deduplicated against `_provision_fit_in_market`; two legacy wrappers (`_provision_market_db`, `_cleanup_market_db`) kept for backwards-compat pending a caller audit; natural file split into `cli_tools/fit_update/` sub-modules.

## Test plan

- [x] Full `pytest tests/` — 330 passed locally
- [x] `mkts-backend fit-update --help` renders
- [ ] Verify on staging: `fit-update assign-market --doctrine-id=<X> --market=deployment --local-only` populates `ship_targets` and `lead_ships` rows for a doctrine previously missing both
- [ ] Verify idempotency: re-running the same `assign-market` leaves the `lead_ships` row unchanged
- [ ] Verify explicit lead-ship is not overwritten: `update-lead-ship` to fit Y, then `assign-market` adds fit Z to same doctrine, `lead_ships` still points at Y
- [ ] Verify `fit-update update-lead-ship --doctrine-id=<X> --fit-id=<Y> --market=both` writes to both `wcmktprod` and `wcmktnorth`
- [ ] Connection count smoke test: with `SQLALCHEMY_ECHO=true`, run `assign-market` on a large doctrine with `--market=both --remote`; count `CONNECT` lines — should be ≤ 4, not per-fit-per-helper

## Diff size

```
 docs/fit_update_simplification_followup.md     | 136 +++++
 docs/market_db_map_deferred.md                 |  95 +++
 src/mkts_backend/cli_tools/command_registry.py |  22 +-
 src/mkts_backend/cli_tools/fit_update.py       | 722 +++++++++++++++----------
 src/mkts_backend/cli_tools/market_args.py      |  21 +
 src/mkts_backend/utils/doctrine_update.py      | 511 ++++++++---------
 6 files changed, 1029 insertions(+), 534 deletions(-)
```

Most of the `fit_update.py` churn is the `_execute_market_plan` and `doctrine_add_fit_command` rewrites; `doctrine_update.py` is largely the `conn=` plumbing across 11 helpers (backwards-compatible — existing `engine=` callers keep working).

🤖 Generated with [Claude Code](https://claude.com/claude-code)