### PR TITLE
refactor(config): centralize settings.toml access; rename config.py to db_config.py

### DIFF
--- a/.github/workflows/market-data-collection.yml
+++ b/.github/workflows/market-data-collection.yml
@@ -57,7 +57,8 @@ jobs:
         modules = [
             'mkts_backend',
             'mkts_backend.cli',
-            'mkts_backend.config.config',
+            'mkts_backend.config.db_config',
+            'mkts_backend.config.settings_service',
             'mkts_backend.config.market_context',
             'mkts_backend.config.logging_config',
             'mkts_backend.db.models',

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,9 +82,9 @@ The primary orchestration file that coordinates all data collection and processi
 - `calculate_doctrine_stats()` - Analyzes ship fitting availability
 - Regional order processing and system-specific market analysis
 
-### Database Layer (`config/config.py`, `db/db_handlers.py`)
+### Database Layer (`config/db_config.py`, `db/db_handlers.py`)
 Manages all database operations:
-- **DatabaseConfig class**: Handles both local SQLite and remote Turso database sync
+- **DatabaseConfig class** (in `config/db_config.py`): Handles both local SQLite and remote Turso database sync
   - Supports MarketContext-based initialization (preferred) or legacy alias-based init
   - `verify_db_exists()`: Ensures database and metadata are in consistent state
     - Handles 4 cases: neither exists, both exist, db without metadata, metadata without db
@@ -148,6 +148,51 @@ Configuration is now managed through `settings.toml` with market-specific config
 - **Market Settings:** `src/mkts_backend/config/settings.toml`
 - **ESI Config:** Auto-generated from MarketContext based on settings.toml
 - **Watchlist:** Database table with ~850 common items and WinterCo doctrine ships/fittings
+
+### Settings Access (`config/settings_service.py`)
+
+All `settings.toml` reads go through a single centralized service. **Do not parse the TOML
+directly** — import `SettingsService` and use a typed property or `settings_dict` for raw access.
+
+```python
+from mkts_backend.config.settings_service import (
+    SettingsService,
+    get_all_market_contexts,
+    get_all_characters,
+    clear_cache,
+)
+
+s = SettingsService()
+s.environment              # "production" or "development"
+s.log_level                # "INFO" / "DEBUG" / ...
+s.esi_user_agent           # User-Agent string for ESI requests
+s.wipe_replace_tables      # ["marketstats", "doctrines", "jita_prices"]
+s.settings_dict            # Raw dict, for keys without a typed accessor
+
+get_all_market_contexts()  # {"primary": MarketContext, "deployment": MarketContext}
+get_all_characters()       # list[CharacterConfig], merges legacy [chareacters] typo section
+```
+
+Behavior:
+- **Module-level cache.** First call parses the TOML; subsequent calls return the cached dict.
+- **Test reload.** Call `settings_service.clear_cache()` after mutating env vars or settings.toml in tests.
+- **Path resolution.** Uses `Path(__file__).parent / "settings.toml"` so it works from any CWD.
+- **Env override.** `MKTS_ENVIRONMENT=development` overrides `[app][environment]` at load time.
+
+### TOML Structure
+
+| Section | Purpose |
+|---|---|
+| `[app]` | Environment + log level |
+| `[esi]` | User-Agent, compatibility date |
+| `[auth]` | OAuth callback + token storage |
+| `[markets.<alias>]` | Per-market configuration (primary, deployment) — preferred over legacy `[market_data]` |
+| `[market_data]` | **Legacy.** Flat-keyed market values still read by `esi_config.py` class-level lookups. Falls back to deriving from `[markets.*]` if absent. |
+| `[db]` | Database aliases and shared file paths (`[db.shared]`) |
+| `[wipe_replace]` | `tables` — list of tables fully wiped/re-inserted on each upsert run (vs. incrementally upserted). Useful for resetting deployment history when switching regions. |
+| `[google_sheets]` | Sheets integration toggle + legacy URLs |
+| `[buildcost]` | `add_structure` CLI source sheet |
+| `[characters.<key>]` | Character definitions for asset checks |
 
 ## External Dependencies
 
@@ -612,7 +657,7 @@ For production deployment with remote database access:
 
 5. **Initial Sync**:
    ```python
-   from mkts_backend.config.config import DatabaseConfig
+   from mkts_backend.config.db_config import DatabaseConfig
 
    # Pull from Turso cloud → local (libsql sync is one-way: cloud → local)
    db = DatabaseConfig("wcmkt")
@@ -848,7 +893,8 @@ Side Channel:
 - **models.py**: Database schema definitions
 - **data_processing.py**: Statistics calculation
 - **gsheets_config.py**: Google Sheets integration
-- **config.py**: Database connection management
+- **db_config.py**: Database connection management (`DatabaseConfig` class)
+- **settings_service.py**: Centralized `settings.toml` loader (`SettingsService` class, module-level cache)
 - **cli_tools/prompter.py**: Multiline input prompter for paste mode (uses prompt_toolkit)
 - **cli_tools/fit_update.py**: Fit and doctrine management CLI commands (includes friendly name management)
 - **cli_tools/equiv_manager.py**: Module equivalents CLI commands (list, find, add, remove)

--- a/scripts/backfill_doctrine_group_category_ids.py
+++ b/scripts/backfill_doctrine_group_category_ids.py
@@ -17,7 +17,7 @@ import sys
 
 from sqlalchemy import text
 
-from mkts_backend.config.config import DatabaseConfig
+from mkts_backend.config.db_config import DatabaseConfig
 
 MARKETS = ("wcmktprod", "wcmktnorth")
 

--- a/src/mkts_backend/cli.py
+++ b/src/mkts_backend/cli.py
@@ -29,12 +29,13 @@ from mkts_backend.config.esi_config import ESIConfig
 from mkts_backend.esi.esi_requests import fetch_market_orders
 from mkts_backend.esi.async_history import run_async_history
 from mkts_backend.utils.validation import validate_all
-from mkts_backend.config.config import load_settings, DatabaseConfig
+from mkts_backend.config.db_config import DatabaseConfig
+from mkts_backend.config.settings_service import SettingsService
 from mkts_backend.cli_tools.args_parser import parse_args
 from mkts_backend.config.gsheets_config import GoogleSheetConfig
 from mkts_backend.config.market_context import MarketContext
 
-settings = load_settings(file_path="src/mkts_backend/config/settings.toml")
+settings = SettingsService().settings_dict
 logger = configure_logging(__name__)
 
 
@@ -255,7 +256,7 @@ def google_sheets_update_workflow(market_ctx: Optional[MarketContext] = None):
         )
     else:
         # Legacy behavior for backward compatibility
-        settings = load_settings(file_path="src/mkts_backend/config/settings.toml")
+        settings = SettingsService().settings_dict
         google_sheet_url2 = settings["google_sheets"]["sheet_url2"]
         google_sheet_config = GoogleSheetConfig(sheet_url=google_sheet_url2)
         update_google_sheet(

--- a/src/mkts_backend/cli_tools/add_structure.py
+++ b/src/mkts_backend/cli_tools/add_structure.py
@@ -22,7 +22,8 @@ Flags
 from __future__ import annotations
 
 from mkts_backend.cli_tools.arg_utils import ParsedArgs
-from mkts_backend.config.config import DatabaseConfig, load_settings
+from mkts_backend.config.db_config import DatabaseConfig
+from mkts_backend.config.settings_service import SettingsService
 from mkts_backend.config.gsheets_config import GoogleSheetConfig
 from mkts_backend.config.logging_config import configure_logging
 from mkts_backend.utils.build_cost_utils import (
@@ -69,7 +70,7 @@ def add_structure(args: list[str], market_alias: str = "primary") -> bool:
         print("Error: --local and --remote-only are mutually exclusive")
         return False
 
-    settings = load_settings()
+    settings = SettingsService().settings_dict
     buildcost_cfg = settings.get("buildcost", {})
     if sheet_url is None:
         sheet_url = buildcost_cfg.get("sheet_url")

--- a/src/mkts_backend/cli_tools/asset_check.py
+++ b/src/mkts_backend/cli_tools/asset_check.py
@@ -9,7 +9,7 @@ from typing import Dict, List, Optional, Tuple
 
 from sqlalchemy import text
 
-from mkts_backend.config.config import DatabaseConfig
+from mkts_backend.config.db_config import DatabaseConfig
 from mkts_backend.config.character_config import CharacterConfig, load_characters
 from mkts_backend.config.logging_config import configure_logging
 from mkts_backend.esi.character_assets import fetch_all_character_assets

--- a/src/mkts_backend/cli_tools/cli_db_commands.py
+++ b/src/mkts_backend/cli_tools/cli_db_commands.py
@@ -1,5 +1,5 @@
 from mkts_backend.config.market_context import MarketContext
-from mkts_backend.config.config import DatabaseConfig
+from mkts_backend.config.db_config import DatabaseConfig
 from sqlalchemy import text
 
 def check_tables(market_alias: str = "primary"):

--- a/src/mkts_backend/cli_tools/command_registry.py
+++ b/src/mkts_backend/cli_tools/command_registry.py
@@ -468,7 +468,7 @@ def _register_all(reg: CommandRegistry) -> None:
     # ── sync ────────────────────────────────────────────────────
     def _handle_sync(args: list[str], market_alias: str) -> bool:
         from mkts_backend.config.market_context import MarketContext
-        from mkts_backend.config.config import DatabaseConfig
+        from mkts_backend.config.db_config import DatabaseConfig
         from mkts_backend.config.logging_config import configure_logging
         from mkts_backend.cli_tools.market_args import expand_market_alias
 
@@ -494,7 +494,7 @@ def _register_all(reg: CommandRegistry) -> None:
     # ── validate ────────────────────────────────────────────────
     def _handle_validate(args: list[str], market_alias: str) -> bool:
         from mkts_backend.config.market_context import MarketContext
-        from mkts_backend.config.config import DatabaseConfig
+        from mkts_backend.config.db_config import DatabaseConfig
         from mkts_backend.cli_tools.market_args import expand_market_alias
 
         all_valid = True

--- a/src/mkts_backend/config/__init__.py
+++ b/src/mkts_backend/config/__init__.py
@@ -1,4 +1,4 @@
-from .config import DatabaseConfig as DatabaseConfig
+from .db_config import DatabaseConfig as DatabaseConfig
 from .esi_config import ESIConfig as ESIConfig
-from .config import load_settings as load_settings
 from .market_context import MarketContext
+from .settings_service import SettingsService

--- a/src/mkts_backend/config/character_config.py
+++ b/src/mkts_backend/config/character_config.py
@@ -4,15 +4,12 @@ Character configuration loader.
 Reads character definitions from settings.toml for asset lookups.
 """
 
-import tomllib
 from dataclasses import dataclass
 from typing import List
 
 from mkts_backend.config.logging_config import configure_logging
 
 logger = configure_logging(__name__)
-
-SETTINGS_FILE = "src/mkts_backend/config/settings.toml"
 
 
 @dataclass
@@ -24,40 +21,17 @@ class CharacterConfig:
     short_name: str
 
 
-def load_characters(settings_file: str = SETTINGS_FILE) -> List[CharacterConfig]:
+def load_characters() -> List[CharacterConfig]:
     """
-    Load character configs from settings.toml.
+    Load character configs via the settings service.
 
     Merges both [characters.*] and [chareacters.*] sections for backward
     compatibility. Characters from [characters] take precedence on key
-    collision.
+    collision. The merge logic lives in
+    ``settings_service.get_all_characters``.
 
     Returns:
         List of CharacterConfig objects
     """
-    with open(settings_file, "rb") as f:
-        settings = tomllib.load(f)
-
-    merged: dict[str, dict] = {}
-
-    # Load legacy typo section first (lower precedence)
-    for key, cfg in settings.get("chareacters", {}).items():
-        if isinstance(cfg, dict):
-            merged[key] = cfg
-
-    # Load correct section (overrides on collision)
-    for key, cfg in settings.get("characters", {}).items():
-        if isinstance(cfg, dict):
-            merged[key] = cfg
-
-    chars = []
-    for key, cfg in merged.items():
-        chars.append(CharacterConfig(
-            key=key,
-            name=cfg.get("name", key),
-            char_id=cfg["char_id"],
-            token_env=cfg.get("token_env", f"REFRESH_TOKEN_{key.upper()}"),
-            short_name=cfg.get("short_name", key[:3].capitalize()),
-        ))
-
-    return chars
+    from mkts_backend.config.settings_service import get_all_characters
+    return get_all_characters()

--- a/src/mkts_backend/config/db_config.py
+++ b/src/mkts_backend/config/db_config.py
@@ -1,41 +1,27 @@
 import os
 from sqlalchemy import create_engine, text
 import pandas as pd
-import pathlib
 from typing import Optional, TYPE_CHECKING
-
-#os.environ.setdefault("RUST_LOG", "debug")
 
 import libsql
 from dotenv import load_dotenv
 from mkts_backend.config.logging_config import configure_logging
-from datetime import datetime, timezone
+from mkts_backend.config.settings_service import SettingsService
+from datetime import datetime
 from time import perf_counter
 import json
 from pathlib import Path
-import tomllib
 
 if TYPE_CHECKING:
     from mkts_backend.config.market_context import MarketContext
 
 load_dotenv()
-settings_file = "src/mkts_backend/config/settings.toml"
 
 logger = configure_logging(__name__)
 
-def load_settings(file_path: str = settings_file):
-    with open(file_path, "rb") as f:
-        settings = tomllib.load(f)
-        logger.debug(f"Settings loaded from {file_path}")
-    # Allow environment variable to override app.environment for temporary switching
-    env_override = os.environ.get("MKTS_ENVIRONMENT")
-    if env_override and "app" in settings:
-        logger.info(f"Environment overridden by MKTS_ENVIRONMENT: {env_override}")
-        settings["app"] = {**settings["app"], "environment": env_override}
-    return settings
 
 class DatabaseConfig:
-    settings = load_settings()
+    settings = SettingsService().settings_dict
     _production_db_alias = settings["db"]["production_database_alias"]
     _production_db_file = settings["db"]["production_database_file"]
     _testing_db_alias = settings["db"]["testing_database_alias"]

--- a/src/mkts_backend/config/db_config.py
+++ b/src/mkts_backend/config/db_config.py
@@ -20,14 +20,23 @@ load_dotenv()
 logger = configure_logging(__name__)
 
 
+def _require_db_key(db_section: dict, key: str) -> str:
+    value = db_section.get(key)
+    if value is None:
+        raise ValueError(
+            f"settings.toml: [db].{key} is required but missing or null."
+        )
+    return value
+
+
 class DatabaseConfig:
     settings = SettingsService().settings_dict
-    _production_db_alias = settings["db"]["production_database_alias"]
-    _production_db_file = settings["db"]["production_database_file"]
-    _testing_db_alias = settings["db"]["testing_database_alias"]
-    _testing_db_file = settings["db"]["testing_database_file"]
-    _deployment_db_alias = settings["db"].get("deployment_database_alias")
-    _deployment_db_file = settings["db"].get("deployment_database_file")
+    _production_db_alias = _require_db_key(settings["db"], "production_database_alias")
+    _production_db_file = _require_db_key(settings["db"], "production_database_file")
+    _testing_db_alias = _require_db_key(settings["db"], "testing_database_alias")
+    _testing_db_file = _require_db_key(settings["db"], "testing_database_file")
+    _deployment_db_alias = _require_db_key(settings["db"], "deployment_database_alias")
+    _deployment_db_file = _require_db_key(settings["db"], "deployment_database_file")
 
 
     _db_paths = {
@@ -81,7 +90,10 @@ class DatabaseConfig:
             self.token = market_context.turso_token
             logger.info(f"DatabaseConfig initialized from MarketContext: {market_context.name}")
         else:
-            env = os.environ.get("MKTS_ENVIRONMENT", self.settings["app"]["environment"])
+            # SettingsService already applied MKTS_ENVIRONMENT override at load
+            # time — re-reading os.environ here would let the two configs drift
+            # if env was changed mid-process.
+            env = self.settings["app"]["environment"]
             if env == 'development':
                 alias = self._testing_db_alias
             elif alias is None or alias in ["wcmkt", "primary", "wcmktprod"]:

--- a/src/mkts_backend/config/esi_config.py
+++ b/src/mkts_backend/config/esi_config.py
@@ -2,7 +2,7 @@ from typing import Optional, TYPE_CHECKING
 
 from mkts_backend.esi.esi_auth import get_token
 from mkts_backend.config.logging_config import configure_logging
-from mkts_backend.config.config import load_settings, settings_file
+from mkts_backend.config.settings_service import SettingsService
 
 if TYPE_CHECKING:
     from mkts_backend.config.market_context import MarketContext
@@ -10,18 +10,19 @@ if TYPE_CHECKING:
 logger = configure_logging(__name__)
 
 
-settings = load_settings(settings_file)
+_service = SettingsService()
+_market_data = _service.get_market_data_legacy()
 
 class ESIConfig:
     """ESI configuration for primary and deployment markets."""
 
     # Legacy class-level lookups for backward compatibility
-    _region_ids = {"primary_region_id": settings["market_data"]["primary_region_id"], "deployment_region_id": settings["market_data"]["deployment_region_id"]}
-    _system_ids = {"primary_system_id": settings["market_data"]["primary_system_id"], "deployment_system_id": settings["market_data"]["deployment_system_id"]}
-    _structure_ids = {"primary_structure_id": settings["market_data"]["primary_structure_id"], "deployment_structure_id": settings["market_data"]["deployment_structure_id"]}
+    _region_ids = {"primary_region_id": _market_data["primary_region_id"], "deployment_region_id": _market_data["deployment_region_id"]}
+    _system_ids = {"primary_system_id": _market_data["primary_system_id"], "deployment_system_id": _market_data["deployment_system_id"]}
+    _structure_ids = {"primary_structure_id": _market_data["primary_structure_id"], "deployment_structure_id": _market_data["deployment_structure_id"]}
     _valid_aliases = ["primary", "deployment"]
     _shortcut_aliases = {"4h": "primary"}
-    _names = {"primary": settings["market_data"]["primary_market_name"], "deployment": settings["market_data"]["deployment_market_name"]}
+    _names = {"primary": _market_data["primary_market_name"], "deployment": _market_data["deployment_market_name"]}
 
     def __init__(
         self,
@@ -65,8 +66,8 @@ class ESIConfig:
             self.system_id = self._system_ids[f"{self.alias}_system_id"]
             self.structure_id = self._structure_ids[f"{self.alias}_structure_id"]
 
-        self.user_agent = settings["esi"]["user_agent"]
-        self.compatibility_date = settings["esi"]["compatibility_date"]
+        self.user_agent = _service.esi_user_agent
+        self.compatibility_date = _service.esi_compatibility_date
 
     def token(self, scope: str = "esi-markets.structure_markets.v1"):
         return get_token(scope)

--- a/src/mkts_backend/config/logging_config.py
+++ b/src/mkts_backend/config/logging_config.py
@@ -4,7 +4,6 @@ from logging import StreamHandler
 import sys
 import os
 from typing import Optional, Dict
-import tomllib
 
 try:
     import colorlog
@@ -23,24 +22,14 @@ def _find_project_root(start_dir: str) -> str:
         cur = parent
     return os.path.abspath(os.path.join(start_dir, "..", "..", "..", ".."))
 
-def _default_settings_file() -> str:
-    project_root = _find_project_root(os.path.dirname(__file__))
-    return os.path.join(project_root, "config", "settings.toml")
-
-def log_level_from_settings(file_path: Optional[str] = None):
-    if file_path is None:
-        file_path = _default_settings_file()
+def _resolve_log_level() -> int:
     try:
-        with open(file_path, "rb") as f:
-            settings = tomllib.load(f)
-        settings_level = settings["app"]["log_level"]
-        if settings_level:
-            return logging.getLevelName(settings_level)
-    except (FileNotFoundError, KeyError):
-        pass
-    return logging.INFO
+        from mkts_backend.config.settings_service import SettingsService
+        return logging.getLevelName(SettingsService().log_level)
+    except (FileNotFoundError, KeyError, Exception):
+        return logging.INFO
 
-log_level = log_level_from_settings()
+log_level = _resolve_log_level()
 
 def configure_logging(
     name: str,

--- a/src/mkts_backend/config/logging_config.py
+++ b/src/mkts_backend/config/logging_config.py
@@ -25,9 +25,13 @@ def _find_project_root(start_dir: str) -> str:
 def _resolve_log_level() -> int:
     try:
         from mkts_backend.config.settings_service import SettingsService
-        return logging.getLevelName(SettingsService().log_level)
-    except (FileNotFoundError, KeyError, Exception):
+        level_name = SettingsService().log_level
+    except (FileNotFoundError, KeyError):
         return logging.INFO
+    level = logging.getLevelName(level_name)
+    if not isinstance(level, int):
+        raise ValueError(f"Invalid log_level in settings: {level_name!r}")
+    return level
 
 log_level = _resolve_log_level()
 

--- a/src/mkts_backend/config/market_context.py
+++ b/src/mkts_backend/config/market_context.py
@@ -8,30 +8,11 @@ needed for a specific market (e.g., primary/4-HWWF or deployment/B-9C24).
 from dataclasses import dataclass
 from typing import Optional
 import os
-import tomllib
 
 from mkts_backend.config.logging_config import configure_logging
+from mkts_backend.config.settings_service import SettingsService
 
 logger = configure_logging(__name__)
-
-# Path to settings file - same as used in config.py
-SETTINGS_FILE = "src/mkts_backend/config/settings.toml"
-
-
-def _load_settings(file_path: str = SETTINGS_FILE) -> dict:
-    """Load settings from TOML file.
-
-    Respects the MKTS_ENVIRONMENT environment variable as a temporary override
-    for settings["app"]["environment"]. Use ``--env=development`` on the CLI
-    or ``export MKTS_ENVIRONMENT=development`` to switch without editing the file.
-    """
-    with open(file_path, "rb") as f:
-        settings = tomllib.load(f)
-    env_override = os.environ.get("MKTS_ENVIRONMENT")
-    if env_override and "app" in settings:
-        logger.info(f"Environment overridden by MKTS_ENVIRONMENT: {env_override}")
-        settings["app"] = {**settings["app"], "environment": env_override}
-    return settings
 
 
 @dataclass
@@ -56,13 +37,12 @@ class MarketContext:
     gsheets_worksheets: dict    # e.g., {"market_data": "market_data_4h", "doctrines": "doctrines_4h"}
 
     @classmethod
-    def from_settings(cls, alias: str, settings_file: str = SETTINGS_FILE) -> "MarketContext":
+    def from_settings(cls, alias: str) -> "MarketContext":
         """
-        Load market context from settings.toml.
+        Load market context from settings via the settings service.
 
         Args:
             alias: Market alias (e.g., "primary", "deployment")
-            settings_file: Path to settings.toml file
 
         Returns:
             MarketContext instance with all configuration for the specified market
@@ -70,24 +50,23 @@ class MarketContext:
         Raises:
             ValueError: If the alias is not found in settings
         """
-        settings = _load_settings(settings_file)
-        markets = settings.get("markets", {})
+        service = SettingsService()
+        markets = service.markets_raw
 
-        if alias not in markets:
-            available = [k for k in markets.keys() if k != "default"]
+        if alias not in markets or not isinstance(markets.get(alias), dict):
+            available = [k for k, v in markets.items() if k != "default" and isinstance(v, dict)]
             raise ValueError(f"Unknown market '{alias}'. Available: {available}")
 
         market_config = markets[alias]
 
-        # Determine database config based on environment
-        environment = settings.get("app", {}).get("environment", "production")
+        environment = service.environment
         db_alias = market_config["database_alias"]
         db_file = market_config["database_file"]
         turso_url_env = market_config["turso_url_env"]
         turso_token_env = market_config["turso_token_env"]
 
         if environment == "development" and alias == "primary":
-            db_section = settings.get("db", {})
+            db_section = service.db_section
             db_alias = db_section.get("testing_database_alias", db_alias)
             db_file = db_section.get("testing_database_file", db_file)
             turso_url_env = db_section.get("testing_turso_url_env", turso_url_env)
@@ -112,38 +91,35 @@ class MarketContext:
         return context
 
     @classmethod
-    def get_default(cls, settings_file: str = SETTINGS_FILE) -> "MarketContext":
+    def get_default(cls) -> "MarketContext":
         """
         Get the default market context as specified in settings.
 
         Returns:
             MarketContext for the default market (typically "primary")
         """
-        settings = _load_settings(settings_file)
-        default_alias = settings.get("markets", {}).get("default", "primary")
-        return cls.from_settings(default_alias, settings_file)
+        return cls.from_settings(SettingsService().default_market_alias)
 
     @classmethod
-    def list_available(cls, settings_file: str = SETTINGS_FILE) -> list[str]:
+    def list_available(cls) -> list[str]:
         """
         List all available market aliases.
 
         Returns:
             List of market alias strings (excludes "default" key)
         """
-        settings = _load_settings(settings_file)
-        markets = settings.get("markets", {})
-        return [k for k in markets.keys() if k != "default"]
+        markets = SettingsService().markets_raw
+        return [k for k, v in markets.items() if k != "default" and isinstance(v, dict)]
 
     @classmethod
-    def get_available_markets(cls, settings_file: str = SETTINGS_FILE) -> list[str]:
+    def get_available_markets(cls) -> list[str]:
         """
         Alias for list_available() - returns all available market aliases.
 
         Returns:
             List of market alias strings
         """
-        return cls.list_available(settings_file)
+        return cls.list_available()
 
     @property
     def turso_url(self) -> Optional[str]:

--- a/src/mkts_backend/config/settings.toml
+++ b/src/mkts_backend/config/settings.toml
@@ -123,6 +123,16 @@ sheet_url = "https://docs.google.com/spreadsheets/d/1aFuInUsgvI1mb-nFNBSwRCGy9Yq
 default_worksheet = ""  # empty = first worksheet in the spreadsheet
 
 # ============================================================================
+# UPDATE BEHAVIOR
+# ============================================================================
+# Tables listed here are fully wiped and re-inserted on each upsert run,
+# rather than incrementally upserted. Useful when stale rows must disappear
+# (e.g., resetting deployment history when switching regions).
+
+[wipe_replace]
+tables = ["marketstats", "doctrines", "jita_prices"]
+
+# ============================================================================
 # CHARACTERS - For Asset Checks
 # ============================================================================
 

--- a/src/mkts_backend/config/settings_service.py
+++ b/src/mkts_backend/config/settings_service.py
@@ -1,0 +1,234 @@
+"""Centralized settings loader for mkts_backend.
+
+This module is the single entry point for reading ``settings.toml``. All other
+config modules (``db_config``, ``market_context``, ``character_config``,
+``esi_config``, ``logging_config``) delegate to this service rather than
+parsing the TOML file themselves.
+
+Architectural rules:
+- Must not import from ``logging_config`` (which depends on this service for
+  ``log_level``) — uses stdlib logging only.
+- Must not import from ``db_config``, ``esi_config``, or other consumers, to
+  avoid circular imports. ``MarketContext`` and ``CharacterConfig`` imports
+  are done lazily inside helper functions.
+"""
+
+import logging
+import os
+import tomllib
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from mkts_backend.config.character_config import CharacterConfig
+    from mkts_backend.config.market_context import MarketContext
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_SETTINGS_PATH = Path(__file__).parent / "settings.toml"
+_cached_settings: dict | None = None
+
+
+def _load_settings(path: Optional[Path] = None) -> dict:
+    """Load and cache settings from the TOML file.
+
+    Applies ``MKTS_ENVIRONMENT`` env var override to ``[app][environment]``
+    at load time. Subsequent calls return the cached dict (overrides are
+    frozen at first load).
+    """
+    global _cached_settings
+    if _cached_settings is not None:
+        return _cached_settings
+
+    settings_path = path if path is not None else _DEFAULT_SETTINGS_PATH
+    try:
+        with open(settings_path, "rb") as f:
+            settings = tomllib.load(f)
+    except Exception as e:
+        logger.error("Failed to load settings from %s: %s", settings_path, e)
+        raise
+
+    env_override = os.environ.get("MKTS_ENVIRONMENT")
+    if env_override and "app" in settings:
+        logger.info("Environment overridden by MKTS_ENVIRONMENT: %s", env_override)
+        settings["app"] = {**settings["app"], "environment": env_override}
+
+    _cached_settings = settings
+    return _cached_settings
+
+
+def clear_cache() -> None:
+    """Drop the cached settings dict. Intended for tests that mutate the TOML."""
+    global _cached_settings
+    _cached_settings = None
+
+
+class SettingsService:
+    """Read-only accessor for application settings.
+
+    Settings are cached at module level after the first read. Instantiating
+    multiple ``SettingsService()`` objects is cheap — they all share the
+    same cached dict.
+    """
+
+    def __init__(self, settings_path: str | Path | None = None):
+        path = Path(settings_path) if settings_path is not None else None
+        self.settings = _load_settings(path)
+
+    @property
+    def settings_dict(self) -> dict:
+        """Return the full settings dictionary for raw access."""
+        return self.settings
+
+    # ---- [app] ----
+
+    @property
+    def app_name(self) -> str:
+        return self.settings["app"]["name"]
+
+    @property
+    def environment(self) -> str:
+        return self.settings["app"]["environment"]
+
+    @property
+    def log_level(self) -> str:
+        return self.settings["app"]["log_level"]
+
+    # ---- [esi] ----
+
+    @property
+    def esi_user_agent(self) -> str:
+        return self.settings["esi"]["user_agent"]
+
+    @property
+    def esi_compatibility_date(self) -> str:
+        return self.settings["esi"]["compatibility_date"]
+
+    # ---- [auth] ----
+
+    @property
+    def auth_callback_url(self) -> str:
+        return self.settings["auth"]["callback_url"]
+
+    @property
+    def auth_token_file(self) -> str:
+        return self.settings["auth"]["token_file"]
+
+    # ---- [wipe_replace] ----
+
+    @property
+    def wipe_replace_tables(self) -> list[str]:
+        """Tables that are fully wiped and re-inserted on each upsert run."""
+        return list(self.settings.get("wipe_replace", {}).get("tables", []))
+
+    # ---- [google_sheets] ----
+
+    @property
+    def gsheets_enabled(self) -> bool:
+        return bool(self.settings.get("google_sheets", {}).get("enabled", False))
+
+    # ---- [buildcost] ----
+
+    @property
+    def buildcost_sheet_url(self) -> str:
+        return self.settings["buildcost"]["sheet_url"]
+
+    @property
+    def buildcost_default_worksheet(self) -> str:
+        return self.settings["buildcost"].get("default_worksheet", "")
+
+    # ---- [markets] ----
+
+    @property
+    def default_market_alias(self) -> str:
+        return self.settings.get("markets", {}).get("default", "primary")
+
+    @property
+    def markets_raw(self) -> dict:
+        """Raw [markets] section, including the 'default' key."""
+        return self.settings.get("markets", {})
+
+    # ---- [db] ----
+
+    @property
+    def db_section(self) -> dict:
+        return self.settings.get("db", {})
+
+    # ---- [market_data] (legacy) ----
+
+    def get_market_data_legacy(self) -> dict:
+        """Return the legacy ``[market_data]`` section.
+
+        If the section is absent (or empty), derives equivalent values from the
+        modern ``[markets.primary]`` and ``[markets.deployment]`` sections so
+        callers that depend on the flat-keyed shape (``primary_region_id`` etc.)
+        keep working. New code should use ``MarketContext`` via
+        ``get_all_market_contexts()`` instead.
+        """
+        market_data = self.settings.get("market_data") or {}
+        if market_data:
+            return market_data
+
+        markets = self.settings.get("markets", {})
+        primary = markets.get("primary", {}) if isinstance(markets.get("primary"), dict) else {}
+        deployment = markets.get("deployment", {}) if isinstance(markets.get("deployment"), dict) else {}
+        return {
+            "primary_region_id": primary.get("region_id", 0),
+            "primary_system_id": primary.get("system_id", 0),
+            "primary_structure_id": primary.get("structure_id", 0),
+            "primary_market_name": primary.get("name", ""),
+            "deployment_region_id": deployment.get("region_id", 0),
+            "deployment_system_id": deployment.get("system_id", 0),
+            "deployment_structure_id": deployment.get("structure_id", 0),
+            "deployment_market_name": deployment.get("name", ""),
+        }
+
+
+# ---- Domain helpers ----
+
+
+def get_all_market_contexts() -> dict[str, "MarketContext"]:
+    """Return ``{alias: MarketContext}`` for every market in settings.
+
+    The ``MarketContext`` import is lazy to avoid circular imports — this
+    service is loaded before ``market_context`` in many call paths.
+    """
+    from mkts_backend.config.market_context import MarketContext
+
+    settings = _load_settings()
+    markets_raw = settings.get("markets", {})
+    contexts: dict[str, "MarketContext"] = {}
+    for alias, market_cfg in markets_raw.items():
+        if alias == "default" or not isinstance(market_cfg, dict):
+            continue
+        contexts[alias] = MarketContext.from_settings(alias)
+    return contexts
+
+
+def get_all_characters() -> list["CharacterConfig"]:
+    """Return all configured characters.
+
+    Merges ``[chareacters.*]`` (legacy typo section, lower precedence) with
+    ``[characters.*]`` (override on key collision).
+    """
+    from mkts_backend.config.character_config import CharacterConfig
+
+    settings = _load_settings()
+    merged: dict[str, dict] = {}
+    for key, cfg in settings.get("chareacters", {}).items():
+        if isinstance(cfg, dict):
+            merged[key] = cfg
+    for key, cfg in settings.get("characters", {}).items():
+        if isinstance(cfg, dict):
+            merged[key] = cfg
+
+    chars = []
+    for key, cfg in merged.items():
+        chars.append(CharacterConfig(
+            key=key,
+            name=cfg.get("name", key),
+            char_id=cfg["char_id"],
+            token_env=cfg.get("token_env", f"REFRESH_TOKEN_{key.upper()}"),
+            short_name=cfg.get("short_name", key[:3].capitalize()),
+        ))
+    return chars

--- a/src/mkts_backend/config/settings_service.py
+++ b/src/mkts_backend/config/settings_service.py
@@ -15,6 +15,7 @@ Architectural rules:
 
 import logging
 import os
+import sys
 import tomllib
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
@@ -32,19 +33,29 @@ _cached_settings: dict | None = None
 def _load_settings(path: Optional[Path] = None) -> dict:
     """Load and cache settings from the TOML file.
 
-    Applies ``MKTS_ENVIRONMENT`` env var override to ``[app][environment]``
-    at load time. Subsequent calls return the cached dict (overrides are
-    frozen at first load).
+    Default path: cached on first call. ``MKTS_ENVIRONMENT`` is read at that
+    first load and frozen — call :func:`clear_cache` to refresh.
+
+    Explicit path: bypasses the cache entirely and never populates it. Tests
+    that swap fixtures don't poison the singleton.
     """
     global _cached_settings
+    if path is not None:
+        return _read_settings_file(path)
     if _cached_settings is not None:
         return _cached_settings
+    _cached_settings = _read_settings_file(_DEFAULT_SETTINGS_PATH)
+    return _cached_settings
 
-    settings_path = path if path is not None else _DEFAULT_SETTINGS_PATH
+
+def _read_settings_file(settings_path: Path) -> dict:
     try:
         with open(settings_path, "rb") as f:
             settings = tomllib.load(f)
     except Exception as e:
+        # Logging may not yet be configured at this bootstrap point — write
+        # to stderr so the user sees the failure even before configure_logging.
+        sys.stderr.write(f"FATAL: Failed to load settings from {settings_path}: {e}\n")
         logger.error("Failed to load settings from %s: %s", settings_path, e)
         raise
 
@@ -53,8 +64,7 @@ def _load_settings(path: Optional[Path] = None) -> dict:
         logger.info("Environment overridden by MKTS_ENVIRONMENT: %s", env_override)
         settings["app"] = {**settings["app"], "environment": env_override}
 
-    _cached_settings = settings
-    return _cached_settings
+    return settings
 
 
 def clear_cache() -> None:
@@ -162,24 +172,36 @@ class SettingsService:
         If the section is absent (or empty), derives equivalent values from the
         modern ``[markets.primary]`` and ``[markets.deployment]`` sections so
         callers that depend on the flat-keyed shape (``primary_region_id`` etc.)
-        keep working. New code should use ``MarketContext`` via
-        ``get_all_market_contexts()`` instead.
+        keep working. Raises ``KeyError`` if a required ID is missing — there
+        is no EVE region/system/structure 0, so silent zero-defaults would just
+        produce 404s far from the root cause. New code should use
+        ``MarketContext`` via ``get_all_market_contexts()`` instead.
         """
         market_data = self.settings.get("market_data") or {}
         if market_data:
             return market_data
 
         markets = self.settings.get("markets", {})
-        primary = markets.get("primary", {}) if isinstance(markets.get("primary"), dict) else {}
-        deployment = markets.get("deployment", {}) if isinstance(markets.get("deployment"), dict) else {}
+        primary = markets.get("primary") if isinstance(markets.get("primary"), dict) else None
+        deployment = markets.get("deployment") if isinstance(markets.get("deployment"), dict) else None
+        if primary is None:
+            raise KeyError(
+                "settings.toml: [market_data] is absent and [markets.primary] "
+                "is missing — cannot derive legacy market data."
+            )
+        if deployment is None:
+            raise KeyError(
+                "settings.toml: [market_data] is absent and [markets.deployment] "
+                "is missing — cannot derive legacy market data."
+            )
         return {
-            "primary_region_id": primary.get("region_id", 0),
-            "primary_system_id": primary.get("system_id", 0),
-            "primary_structure_id": primary.get("structure_id", 0),
+            "primary_region_id": primary["region_id"],
+            "primary_system_id": primary["system_id"],
+            "primary_structure_id": primary["structure_id"],
             "primary_market_name": primary.get("name", ""),
-            "deployment_region_id": deployment.get("region_id", 0),
-            "deployment_system_id": deployment.get("system_id", 0),
-            "deployment_structure_id": deployment.get("structure_id", 0),
+            "deployment_region_id": deployment["region_id"],
+            "deployment_system_id": deployment["system_id"],
+            "deployment_structure_id": deployment["structure_id"],
             "deployment_market_name": deployment.get("name", ""),
         }
 

--- a/src/mkts_backend/db/db_handlers.py
+++ b/src/mkts_backend/db/db_handlers.py
@@ -19,7 +19,8 @@ from mkts_backend.utils.utils import (
 )
 from mkts_backend.config.logging_config import configure_logging
 from mkts_backend.db.models import Base, MarketHistory, MarketOrders, UpdateLog, ESIRequestCache
-from mkts_backend.config.config import DatabaseConfig
+from mkts_backend.config.db_config import DatabaseConfig
+from mkts_backend.config.settings_service import SettingsService
 from mkts_backend.db.db_queries import get_table_length, get_remote_status
 
 if TYPE_CHECKING:
@@ -132,9 +133,9 @@ def upsert_database(
     Returns:
         True if successful, False otherwise
     """
-    WIPE_REPLACE_TABLES = ["marketstats", "doctrines", "jita_prices"]
+    wipe_replace_tables = SettingsService().wipe_replace_tables
     tabname = table.__tablename__
-    is_wipe_replace = tabname in WIPE_REPLACE_TABLES
+    is_wipe_replace = tabname in wipe_replace_tables
     logger.info(f"Processing table: {tabname}, wipe_replace: {is_wipe_replace}")
     logger.info(f"Upserting {len(df)} rows into {table.__tablename__}")
 

--- a/src/mkts_backend/db/db_queries.py
+++ b/src/mkts_backend/db/db_queries.py
@@ -1,7 +1,7 @@
 from sqlalchemy import text
 from typing import Optional, TYPE_CHECKING
 import pandas as pd
-from mkts_backend.config.config import DatabaseConfig
+from mkts_backend.config.db_config import DatabaseConfig
 
 if TYPE_CHECKING:
     from mkts_backend.config.market_context import MarketContext

--- a/src/mkts_backend/db/equiv_handlers.py
+++ b/src/mkts_backend/db/equiv_handlers.py
@@ -9,7 +9,7 @@ from typing import Optional, TYPE_CHECKING
 from sqlalchemy import text
 
 from mkts_backend.config.logging_config import configure_logging
-from mkts_backend.config.config import DatabaseConfig
+from mkts_backend.config.db_config import DatabaseConfig
 
 if TYPE_CHECKING:
     from mkts_backend.config.market_context import MarketContext

--- a/src/mkts_backend/esi/async_history.py
+++ b/src/mkts_backend/esi/async_history.py
@@ -4,7 +4,7 @@ import time
 import httpx
 from aiolimiter import AsyncLimiter
 from typing import Optional, TYPE_CHECKING
-from mkts_backend.config.config import DatabaseConfig
+from mkts_backend.config.db_config import DatabaseConfig
 from mkts_backend.config.esi_config import ESIConfig
 from mkts_backend.config.logging_config import configure_logging
 

--- a/src/mkts_backend/esi/esi_requests.py
+++ b/src/mkts_backend/esi/esi_requests.py
@@ -2,7 +2,7 @@ import os
 
 from mkts_backend.config.esi_config import ESIConfig
 from mkts_backend.config.logging_config import configure_logging
-from mkts_backend.config.config import load_settings, settings_file
+from mkts_backend.config.settings_service import SettingsService
 import requests
 import time
 import json
@@ -11,8 +11,7 @@ import millify
 
 logger = configure_logging(__name__)
 
-_settings = load_settings(settings_file)
-_USER_AGENT = _settings["esi"]["user_agent"]
+_USER_AGENT = SettingsService().esi_user_agent
 
 # Check if terminal output (progress prints) should be suppressed.
 # Set MKTS_QUIET=1 in CI/GitHub Actions to disable progress output.

--- a/src/mkts_backend/processing/data_processing.py
+++ b/src/mkts_backend/processing/data_processing.py
@@ -3,7 +3,7 @@ from typing import Optional, TYPE_CHECKING
 from mkts_backend.config.logging_config import configure_logging
 from mkts_backend.utils.db_utils import fix_null_doctrine_stats_timestamps
 from mkts_backend.db.models import MarketStats, MarketHistory
-from mkts_backend.config.config import DatabaseConfig
+from mkts_backend.config.db_config import DatabaseConfig
 from sqlalchemy.orm import Session
 from sqlalchemy import select, func
 from mkts_backend.db.db_queries import get_remote_status

--- a/src/mkts_backend/utils/add2doctrines_table.py
+++ b/src/mkts_backend/utils/add2doctrines_table.py
@@ -1,4 +1,4 @@
-from mkts_backend.config.config import DatabaseConfig
+from mkts_backend.config.db_config import DatabaseConfig
 from sqlalchemy import text, select, delete, func
 from sqlalchemy.orm import Session
 from mkts_backend.db.models import Doctrines

--- a/src/mkts_backend/utils/db_utils.py
+++ b/src/mkts_backend/utils/db_utils.py
@@ -1,6 +1,6 @@
 import pandas as pd
 from sqlalchemy import text, insert, select, bindparam
-from mkts_backend.config.config import DatabaseConfig
+from mkts_backend.config.db_config import DatabaseConfig
 from mkts_backend.config.logging_config import configure_logging
 from mkts_backend.db.models import Watchlist, UpdateLog
 from datetime import datetime, timezone, timedelta

--- a/src/mkts_backend/utils/doctrine_update.py
+++ b/src/mkts_backend/utils/doctrine_update.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 from mkts_backend.db.models import Doctrines, LeadShips, DoctrineFitItems, Base
 from mkts_backend.db.db_queries import get_watchlist_ids, get_fit_ids, get_fit_items
 from mkts_backend.utils.get_type_info import TypeInfo
-from mkts_backend.config.config import DatabaseConfig
+from mkts_backend.config.db_config import DatabaseConfig
 from mkts_backend.config.logging_config import configure_logging
 from mkts_backend.utils.utils import get_type_name
 

--- a/src/mkts_backend/utils/get_type_info.py
+++ b/src/mkts_backend/utils/get_type_info.py
@@ -4,7 +4,7 @@ from typing import Union
 from numpy._core.multiarray import RAISE
 from numpy.strings import isdigit, isnumeric
 from sqlalchemy.orm import query
-from mkts_backend.config.config import DatabaseConfig
+from mkts_backend.config.db_config import DatabaseConfig
 from sqlalchemy import false, text
 from mkts_backend.config.logging_config import configure_logging
 

--- a/src/mkts_backend/utils/parse_items.py
+++ b/src/mkts_backend/utils/parse_items.py
@@ -2,7 +2,7 @@ import csv
 import re
 from sqlalchemy import text
 from mkts_backend.config.logging_config import configure_logging
-from mkts_backend.config.config import DatabaseConfig
+from mkts_backend.config.db_config import DatabaseConfig
 from mkts_backend.utils.utils import init_databases
 
 logger = configure_logging(__name__)

--- a/src/mkts_backend/utils/utils.py
+++ b/src/mkts_backend/utils/utils.py
@@ -6,7 +6,7 @@ import pandas as pd
 import json
 import sqlalchemy as sa
 from sqlalchemy import text, create_engine
-from mkts_backend.config.config import DatabaseConfig
+from mkts_backend.config.db_config import DatabaseConfig
 from mkts_backend.config.esi_config import ESIConfig
 from mkts_backend.config.logging_config import configure_logging
 from sqlalchemy.orm import Session

--- a/src/mkts_backend/utils/validation.py
+++ b/src/mkts_backend/utils/validation.py
@@ -180,7 +180,7 @@ def validate_all() -> Dict:
 
 def validate_db_credentials():
     """Legacy function - kept for backward compatibility."""
-    from mkts_backend.config.config import DatabaseConfig
+    from mkts_backend.config.db_config import DatabaseConfig
     db = DatabaseConfig("wcmkt")
     credentials = db.get_db_credentials_dicts()
     return credentials

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,15 +14,15 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 
 @pytest.fixture
-def primary_market_context():
+def primary_market_context(monkeypatch):
     """Create a primary market context for testing (forces development mode)."""
-    from mkts_backend.config.market_context import MarketContext, _load_settings
+    from mkts_backend.config.market_context import MarketContext
+    from mkts_backend.config.settings_service import clear_cache
 
-    settings = _load_settings()
-    settings["app"]["environment"] = "development"
-
-    with patch("mkts_backend.config.market_context._load_settings", return_value=settings):
-        return MarketContext.from_settings("primary")
+    monkeypatch.setenv("MKTS_ENVIRONMENT", "development")
+    clear_cache()
+    yield MarketContext.from_settings("primary")
+    clear_cache()
 
 
 @pytest.fixture
@@ -162,8 +162,8 @@ def mock_database_config(temp_db_dir):
     original_init = None
 
     def mock_init(self, alias=None, dialect="sqlite+libsql", market_context=None):
-        from mkts_backend.config.config import load_settings
-        self.settings = load_settings()
+        from mkts_backend.config.settings_service import SettingsService
+        self.settings = SettingsService().settings_dict
 
         if market_context is not None:
             self.alias = market_context.database_alias
@@ -194,7 +194,7 @@ def mock_database_config(temp_db_dir):
         self._engine = None
         self._session = None
 
-    with patch("mkts_backend.config.config.DatabaseConfig.__init__", mock_init):
+    with patch("mkts_backend.config.db_config.DatabaseConfig.__init__", mock_init):
         yield temp_db_dir
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,19 @@ import sys
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 
+@pytest.fixture(autouse=True)
+def _settings_cache_isolation():
+    """Drop the cached settings dict before/after every test.
+
+    Prevents env-override and TOML-mutation pollution from leaking between
+    tests via the module-level cache in ``settings_service``.
+    """
+    from mkts_backend.config.settings_service import clear_cache
+    clear_cache()
+    yield
+    clear_cache()
+
+
 @pytest.fixture
 def primary_market_context(monkeypatch):
     """Create a primary market context for testing (forces development mode)."""

--- a/tests/test_add_structure.py
+++ b/tests/test_add_structure.py
@@ -488,8 +488,13 @@ def test_cli_partial_success_remote_ok_local_fails(cli_env, buildcost_engine, tm
 
 def test_cli_missing_sheet_url_errors(cli_env, monkeypatch, capsys):
     """With no --file and no configured sheet_url, handler reports a clean error."""
-    from mkts_backend.cli_tools import add_structure as mod
-    monkeypatch.setattr(mod, "load_settings", lambda: {"buildcost": {}})
+    from mkts_backend.config import settings_service
+    monkeypatch.setattr(
+        settings_service,
+        "_load_settings",
+        lambda path=None: {"buildcost": {}, "app": {"environment": "production"}},
+    )
+    settings_service.clear_cache()
 
     result = cli_env.add_structure(["--yes"])
     out = capsys.readouterr().out

--- a/tests/test_database_routing.py
+++ b/tests/test_database_routing.py
@@ -81,7 +81,7 @@ class TestESIConfigRouting:
 
         esi = ESIConfig(market_context=deployment_market_context)
 
-        assert esi.region_id == 10000003
+        assert esi.region_id == 10000023
         assert esi.structure_id == 1041669946862
 
     def test_esi_config_primary_and_deployment_have_different_structures(
@@ -89,8 +89,9 @@ class TestESIConfigRouting:
     ):
         """Test that primary and deployment ESI configs target different structures.
 
-        Both markets currently share region_id=10000003, so isolation is verified
-        via structure_id (which uniquely identifies the market hub).
+        Primary is in region_id=10000003 (Vale of Silent), deployment is in
+        region_id=10000023 (Pure Blind). structure_id uniquely identifies the
+        market hub within each region.
         """
         from mkts_backend.config.esi_config import ESIConfig
 

--- a/tests/test_database_routing.py
+++ b/tests/test_database_routing.py
@@ -14,7 +14,7 @@ class TestDatabaseConfigRouting:
 
     def test_database_config_uses_primary_market_context(self, primary_market_context):
         """Test DatabaseConfig uses primary market context settings."""
-        from mkts_backend.config.config import DatabaseConfig
+        from mkts_backend.config.db_config import DatabaseConfig
 
         db = DatabaseConfig(market_context=primary_market_context)
 
@@ -23,7 +23,7 @@ class TestDatabaseConfigRouting:
 
     def test_database_config_uses_deployment_market_context(self, deployment_market_context):
         """Test DatabaseConfig uses deployment market context settings."""
-        from mkts_backend.config.config import DatabaseConfig
+        from mkts_backend.config.db_config import DatabaseConfig
 
         db = DatabaseConfig(market_context=deployment_market_context)
 
@@ -34,7 +34,7 @@ class TestDatabaseConfigRouting:
         self, primary_market_context, deployment_market_context
     ):
         """Test that primary and deployment create different database paths."""
-        from mkts_backend.config.config import DatabaseConfig
+        from mkts_backend.config.db_config import DatabaseConfig
 
         primary_db = DatabaseConfig(market_context=primary_market_context)
         deployment_db = DatabaseConfig(market_context=deployment_market_context)
@@ -44,7 +44,7 @@ class TestDatabaseConfigRouting:
 
     def test_database_config_legacy_alias_still_works(self):
         """Test that legacy alias-based initialization still works."""
-        from mkts_backend.config.config import DatabaseConfig
+        from mkts_backend.config.db_config import DatabaseConfig
 
         # Legacy initialization without market_context
         # "wcmkt" alias maps to wcmktprod in the new config
@@ -55,7 +55,7 @@ class TestDatabaseConfigRouting:
 
     def test_database_config_market_context_takes_precedence(self, primary_market_context):
         """Test that market_context takes precedence over alias parameter."""
-        from mkts_backend.config.config import DatabaseConfig
+        from mkts_backend.config.db_config import DatabaseConfig
 
         # Even if alias is provided, market_context should take precedence
         db = DatabaseConfig(alias="something_else", market_context=primary_market_context)
@@ -73,7 +73,7 @@ class TestESIConfigRouting:
         esi = ESIConfig(market_context=primary_market_context)
 
         assert esi.region_id == 10000003
-        assert esi.structure_id == 1035466617946
+        assert esi.structure_id == 1053654548169
 
     def test_esi_config_uses_deployment_market_context(self, deployment_market_context):
         """Test ESIConfig uses deployment market context settings."""
@@ -81,19 +81,22 @@ class TestESIConfigRouting:
 
         esi = ESIConfig(market_context=deployment_market_context)
 
-        assert esi.region_id == 10000023
-        assert esi.structure_id == 1046831245129
+        assert esi.region_id == 10000003
+        assert esi.structure_id == 1041669946862
 
-    def test_esi_config_primary_and_deployment_different_regions(
+    def test_esi_config_primary_and_deployment_have_different_structures(
         self, primary_market_context, deployment_market_context
     ):
-        """Test that primary and deployment have different ESI settings."""
+        """Test that primary and deployment ESI configs target different structures.
+
+        Both markets currently share region_id=10000003, so isolation is verified
+        via structure_id (which uniquely identifies the market hub).
+        """
         from mkts_backend.config.esi_config import ESIConfig
 
         primary_esi = ESIConfig(market_context=primary_market_context)
         deployment_esi = ESIConfig(market_context=deployment_market_context)
 
-        assert primary_esi.region_id != deployment_esi.region_id
         assert primary_esi.structure_id != deployment_esi.structure_id
 
     def test_esi_config_market_orders_url_primary(self, primary_market_context):
@@ -324,7 +327,7 @@ class TestDatabaseIsolation:
         self, primary_market_context, deployment_market_context
     ):
         """Test that database paths contain correct market identifiers."""
-        from mkts_backend.config.config import DatabaseConfig
+        from mkts_backend.config.db_config import DatabaseConfig
 
         primary_db = DatabaseConfig(market_context=primary_market_context)
         deployment_db = DatabaseConfig(market_context=deployment_market_context)
@@ -343,7 +346,7 @@ class TestCrossMarketIsolation:
         self, primary_market_context, deployment_market_context
     ):
         """Test that sequential operations on different markets use correct databases."""
-        from mkts_backend.config.config import DatabaseConfig
+        from mkts_backend.config.db_config import DatabaseConfig
 
         # First operation - primary market
         db1 = DatabaseConfig(market_context=primary_market_context)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -63,7 +63,7 @@ class TestMarketContextConfigChain:
         gsheets = GoogleSheetConfig(market_context=deployment_market_context)
 
         assert db.alias == "wcmktnorth"
-        assert esi.region_id == 10000003
+        assert esi.region_id == 10000023
         assert esi.structure_id == 1041669946862
         assert gsheets.google_sheet_url == deployment_market_context.gsheets_url
 
@@ -154,7 +154,7 @@ class TestBackwardCompatibility:
         esi = ESIConfig("deployment")
 
         assert esi.alias == "deployment"
-        assert esi.region_id == 10000003  # Vale of Silent
+        assert esi.region_id == 10000023  # Pure Blind
         assert esi.structure_id == 1041669946862  # X47L-Q
         assert esi.market_orders_url is not None
         assert "structures" in esi.market_orders_url

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -16,7 +16,7 @@ class TestFullMarketContextFlow:
 
     def test_primary_market_flow_uses_correct_database(self, primary_market_context):
         """Test that primary market operations use wcmkttest database in development."""
-        from mkts_backend.config.config import DatabaseConfig
+        from mkts_backend.config.db_config import DatabaseConfig
 
         db = DatabaseConfig(market_context=primary_market_context)
 
@@ -25,7 +25,7 @@ class TestFullMarketContextFlow:
 
     def test_deployment_market_flow_uses_correct_database(self, deployment_market_context):
         """Test that deployment market operations use wcmktnorth database."""
-        from mkts_backend.config.config import DatabaseConfig
+        from mkts_backend.config.db_config import DatabaseConfig
 
         db = DatabaseConfig(market_context=deployment_market_context)
 
@@ -38,7 +38,7 @@ class TestMarketContextConfigChain:
 
     def test_config_chain_primary(self, primary_market_context):
         """Test full config chain for primary market."""
-        from mkts_backend.config.config import DatabaseConfig
+        from mkts_backend.config.db_config import DatabaseConfig
         from mkts_backend.config.esi_config import ESIConfig
         from mkts_backend.config.gsheets_config import GoogleSheetConfig
 
@@ -53,7 +53,7 @@ class TestMarketContextConfigChain:
 
     def test_config_chain_deployment(self, deployment_market_context):
         """Test full config chain for deployment market."""
-        from mkts_backend.config.config import DatabaseConfig
+        from mkts_backend.config.db_config import DatabaseConfig
         from mkts_backend.config.esi_config import ESIConfig
         from mkts_backend.config.gsheets_config import GoogleSheetConfig
 
@@ -63,7 +63,8 @@ class TestMarketContextConfigChain:
         gsheets = GoogleSheetConfig(market_context=deployment_market_context)
 
         assert db.alias == "wcmktnorth"
-        assert esi.region_id == 10000023
+        assert esi.region_id == 10000003
+        assert esi.structure_id == 1041669946862
         assert gsheets.google_sheet_url == deployment_market_context.gsheets_url
 
 
@@ -123,7 +124,7 @@ class TestBackwardCompatibility:
 
     def test_legacy_alias_initialization_works(self):
         """Test that legacy alias-based initialization still works."""
-        from mkts_backend.config.config import DatabaseConfig
+        from mkts_backend.config.db_config import DatabaseConfig
 
         # Legacy way of creating database config
         db = DatabaseConfig("wcmkt")
@@ -153,8 +154,8 @@ class TestBackwardCompatibility:
         esi = ESIConfig("deployment")
 
         assert esi.alias == "deployment"
-        assert esi.region_id == 10000023  # Pure Blind
-        assert esi.structure_id == 1046831245129  # B-9C24
+        assert esi.region_id == 10000003  # Vale of Silent
+        assert esi.structure_id == 1041669946862  # X47L-Q
         assert esi.market_orders_url is not None
         assert "structures" in esi.market_orders_url
 
@@ -293,7 +294,7 @@ class TestConcurrentMarketOperations:
 
     def test_concurrent_config_creation(self, primary_market_context, deployment_market_context):
         """Test creating configs for multiple markets concurrently."""
-        from mkts_backend.config.config import DatabaseConfig
+        from mkts_backend.config.db_config import DatabaseConfig
 
         configs = []
 

--- a/tests/test_market_context.py
+++ b/tests/test_market_context.py
@@ -29,7 +29,7 @@ class TestMarketContextCreation:
 
         assert ctx.alias == "deployment"
         assert ctx.name == "X47L-Q - Rogue Threshold"
-        assert ctx.region_id == 10000003
+        assert ctx.region_id == 10000023
         assert ctx.structure_id == 1041669946862
         assert ctx.database_alias == "wcmktnorth"
         assert ctx.database_file == "wcmktnorth2.db"
@@ -74,11 +74,13 @@ class TestMarketContextCreation:
     ):
         """Test that primary and deployment markets are distinct locations.
 
-        Both markets currently share region_id=10000003, so isolation is verified
-        via structure_id and system_id (which uniquely identify the market hub).
+        Primary is in region_id=10000003 (Vale of Silent), deployment is in
+        region_id=10000023 (Pure Blind). structure_id and system_id uniquely
+        identify the market hub within each region.
         """
         assert primary_market_context.structure_id != deployment_market_context.structure_id
         assert primary_market_context.system_id != deployment_market_context.system_id
+        assert primary_market_context.region_id != deployment_market_context.region_id
 
     def test_invalid_market_alias_raises_error(self):
         """Test that invalid market alias raises ValueError."""

--- a/tests/test_market_context.py
+++ b/tests/test_market_context.py
@@ -14,9 +14,9 @@ class TestMarketContextCreation:
         ctx = primary_market_context
 
         assert ctx.alias == "primary"
-        assert ctx.name == "4-HWWF Keepstar"
+        assert ctx.name == "4-HWWF - Platestar"
         assert ctx.region_id == 10000003
-        assert ctx.structure_id == 1035466617946
+        assert ctx.structure_id == 1053654548169
         # In development mode, primary should use testing database
         assert ctx.database_alias == "wcmkttest"
         assert ctx.database_file == "wcmkttest.db"
@@ -28,23 +28,23 @@ class TestMarketContextCreation:
         ctx = deployment_market_context
 
         assert ctx.alias == "deployment"
-        assert ctx.name == "B-9C24 Keepstar"
-        assert ctx.region_id == 10000023
-        assert ctx.structure_id == 1046831245129
+        assert ctx.name == "X47L-Q - Rogue Threshold"
+        assert ctx.region_id == 10000003
+        assert ctx.structure_id == 1041669946862
         assert ctx.database_alias == "wcmktnorth"
         assert ctx.database_file == "wcmktnorth2.db"
         assert ctx.turso_url_env == "TURSO_WCMKTNORTH_URL"
         assert ctx.turso_token_env == "TURSO_WCMKTNORTH_TOKEN"
 
-    def test_create_primary_market_context_production(self):
+    def test_create_primary_market_context_production(self, monkeypatch):
         """Test that primary market context uses production db in production mode."""
-        from mkts_backend.config.market_context import MarketContext, _load_settings
+        from mkts_backend.config.market_context import MarketContext
+        from mkts_backend.config.settings_service import clear_cache
 
-        real_settings = _load_settings()
-        real_settings["app"]["environment"] = "production"
-
-        with patch("mkts_backend.config.market_context._load_settings", return_value=real_settings):
-            ctx = MarketContext.from_settings("primary")
+        monkeypatch.setenv("MKTS_ENVIRONMENT", "production")
+        clear_cache()
+        ctx = MarketContext.from_settings("primary")
+        clear_cache()
 
         assert ctx.alias == "primary"
         assert ctx.database_alias == "wcmktprod"
@@ -59,7 +59,7 @@ class TestMarketContextCreation:
         default = MarketContext.get_default()
 
         assert default.alias == "primary"
-        assert default.name == "4-HWWF Keepstar"
+        assert default.name == "4-HWWF - Platestar"
 
     def test_primary_and_deployment_have_different_databases(
         self, primary_market_context, deployment_market_context
@@ -69,12 +69,16 @@ class TestMarketContextCreation:
         assert primary_market_context.database_file != deployment_market_context.database_file
         assert primary_market_context.turso_url_env != deployment_market_context.turso_url_env
 
-    def test_primary_and_deployment_have_different_regions(
+    def test_primary_and_deployment_are_different_locations(
         self, primary_market_context, deployment_market_context
     ):
-        """Test that primary and deployment markets use different regions."""
-        assert primary_market_context.region_id != deployment_market_context.region_id
+        """Test that primary and deployment markets are distinct locations.
+
+        Both markets currently share region_id=10000003, so isolation is verified
+        via structure_id and system_id (which uniquely identify the market hub).
+        """
         assert primary_market_context.structure_id != deployment_market_context.structure_id
+        assert primary_market_context.system_id != deployment_market_context.system_id
 
     def test_invalid_market_alias_raises_error(self):
         """Test that invalid market alias raises ValueError."""
@@ -135,21 +139,21 @@ class TestMarketContextIsolation:
         assert "WCMKTTEST" in primary_url_env
         assert "WCMKTNORTH" in deployment_url_env
 
-    def test_deployment_unaffected_by_environment(self):
+    def test_deployment_unaffected_by_environment(self, monkeypatch):
         """Test that deployment market is not affected by environment setting."""
-        from mkts_backend.config.market_context import MarketContext, _load_settings
+        from mkts_backend.config.market_context import MarketContext
+        from mkts_backend.config.settings_service import clear_cache
 
         # Test in development mode
-        dev_settings = _load_settings()
-        dev_settings["app"]["environment"] = "development"
-        with patch("mkts_backend.config.market_context._load_settings", return_value=dev_settings):
-            dev_ctx = MarketContext.from_settings("deployment")
+        monkeypatch.setenv("MKTS_ENVIRONMENT", "development")
+        clear_cache()
+        dev_ctx = MarketContext.from_settings("deployment")
 
         # Test in production mode
-        prod_settings = _load_settings()
-        prod_settings["app"]["environment"] = "production"
-        with patch("mkts_backend.config.market_context._load_settings", return_value=prod_settings):
-            prod_ctx = MarketContext.from_settings("deployment")
+        monkeypatch.setenv("MKTS_ENVIRONMENT", "production")
+        clear_cache()
+        prod_ctx = MarketContext.from_settings("deployment")
+        clear_cache()
 
         assert dev_ctx.database_alias == prod_ctx.database_alias == "wcmktnorth"
         assert dev_ctx.database_file == prod_ctx.database_file == "wcmktnorth2.db"

--- a/tests/test_settings_service.py
+++ b/tests/test_settings_service.py
@@ -1,5 +1,7 @@
 """Tests for the centralized settings service."""
 
+import tomllib
+
 import pytest
 
 from mkts_backend.config.settings_service import (
@@ -84,3 +86,115 @@ def test_market_data_legacy_falls_back_to_markets_section():
     assert md["primary_region_id"] == 1
     assert md["deployment_structure_id"] == 6
     assert md["primary_market_name"] == "Primary"
+
+
+# ---------------------------------------------------------------------------
+# Error-path coverage
+# ---------------------------------------------------------------------------
+
+
+def test_missing_settings_file_raises(tmp_path):
+    missing = tmp_path / "nope.toml"
+    with pytest.raises(FileNotFoundError):
+        SettingsService(settings_path=missing)
+
+
+def test_malformed_toml_raises(tmp_path):
+    bad = tmp_path / "bad.toml"
+    bad.write_text("this is = not = valid\n")
+    with pytest.raises(tomllib.TOMLDecodeError):
+        SettingsService(settings_path=bad)
+
+
+def test_explicit_path_bypasses_cache(tmp_path):
+    """Explicit settings_path must not read or pollute the module cache."""
+    fixture = tmp_path / "alt.toml"
+    fixture.write_text(
+        '[app]\nname = "alt"\nenvironment = "development"\nlog_level = "DEBUG"\n'
+        '[esi]\nuser_agent = "alt"\ncompatibility_date = "2026-01-01"\n'
+        '[auth]\ncallback_url = "http://x"\ntoken_file = "file:t.json"\n'
+        '[buildcost]\nsheet_url = "http://x"\n'
+    )
+    alt = SettingsService(settings_path=fixture)
+    assert alt.app_name == "alt"
+
+    # Default path still loads fresh — explicit path didn't poison the cache.
+    default = SettingsService()
+    assert default.app_name != "alt"
+
+
+def test_market_data_legacy_raises_when_primary_missing():
+    """Missing [markets.primary] should raise — not return zeros."""
+    s = SettingsService.__new__(SettingsService)
+    s.settings = {"markets": {"deployment": {"region_id": 1, "system_id": 2, "structure_id": 3}}}
+    with pytest.raises(KeyError, match=r"\[markets\.primary\]"):
+        s.get_market_data_legacy()
+
+
+def test_market_data_legacy_raises_when_deployment_missing():
+    s = SettingsService.__new__(SettingsService)
+    s.settings = {"markets": {"primary": {"region_id": 1, "system_id": 2, "structure_id": 3}}}
+    with pytest.raises(KeyError, match=r"\[markets\.deployment\]"):
+        s.get_market_data_legacy()
+
+
+def test_market_data_legacy_raises_when_required_id_missing():
+    """A [markets.primary] without region_id should fail loudly, not zero-default."""
+    s = SettingsService.__new__(SettingsService)
+    s.settings = {
+        "markets": {
+            "primary": {"name": "P", "system_id": 2, "structure_id": 3},  # no region_id
+            "deployment": {"region_id": 4, "system_id": 5, "structure_id": 6},
+        }
+    }
+    with pytest.raises(KeyError, match="region_id"):
+        s.get_market_data_legacy()
+
+
+def test_environment_override_frozen_after_first_load(monkeypatch):
+    """Document the freeze: env changed after first load is ignored."""
+    monkeypatch.setenv("MKTS_ENVIRONMENT", "production")
+    clear_cache()
+    SettingsService()  # first load — freezes env=production
+    monkeypatch.setenv("MKTS_ENVIRONMENT", "development")
+    # No clear_cache — production is still frozen in.
+    assert SettingsService().environment == "production"
+
+
+def test_environment_override_unset_falls_back_to_toml(monkeypatch):
+    monkeypatch.delenv("MKTS_ENVIRONMENT", raising=False)
+    clear_cache()
+    s = SettingsService()
+    # The TOML default is "production"; if you change it, update this assertion.
+    assert s.environment == "production"
+
+
+def test_get_all_characters_requires_char_id(monkeypatch):
+    """A character entry missing char_id should fail loudly."""
+    from mkts_backend.config import settings_service as svc
+
+    monkeypatch.setattr(
+        svc,
+        "_load_settings",
+        lambda path=None: {"characters": {"foo": {"name": "Foo"}}},
+    )
+    with pytest.raises(KeyError, match="char_id"):
+        get_all_characters()
+
+
+def test_get_all_characters_correct_section_overrides_typo(monkeypatch):
+    """[characters.*] should override [chareacters.*] on key collision."""
+    from mkts_backend.config import settings_service as svc
+
+    monkeypatch.setattr(
+        svc,
+        "_load_settings",
+        lambda path=None: {
+            "chareacters": {"foo": {"char_id": 1, "name": "Old"}},
+            "characters": {"foo": {"char_id": 2, "name": "New"}, "bar": {"char_id": 3}},
+        },
+    )
+    chars = {c.key: c for c in get_all_characters()}
+    assert chars["foo"].char_id == 2
+    assert chars["foo"].name == "New"
+    assert "bar" in chars

--- a/tests/test_settings_service.py
+++ b/tests/test_settings_service.py
@@ -1,0 +1,86 @@
+"""Tests for the centralized settings service."""
+
+import pytest
+
+from mkts_backend.config.settings_service import (
+    SettingsService,
+    _load_settings,
+    clear_cache,
+    get_all_characters,
+    get_all_market_contexts,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    clear_cache()
+    yield
+    clear_cache()
+
+
+def test_settings_loads_and_exposes_typed_properties():
+    s = SettingsService()
+    assert s.environment in {"production", "development"}
+    assert s.log_level in {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+    assert s.esi_user_agent.startswith("wcmkts_backend/")
+    assert s.wipe_replace_tables == ["marketstats", "doctrines", "jita_prices"]
+
+
+def test_cache_is_shared_across_instances():
+    a = SettingsService().settings_dict
+    b = SettingsService().settings_dict
+    assert a is b
+
+
+def test_clear_cache_forces_reload():
+    first = SettingsService().settings_dict
+    clear_cache()
+    second = SettingsService().settings_dict
+    assert first is not second
+
+
+def test_mkts_environment_override(monkeypatch):
+    monkeypatch.setenv("MKTS_ENVIRONMENT", "development")
+    clear_cache()
+    assert SettingsService().environment == "development"
+
+
+def test_get_all_market_contexts_returns_primary_and_deployment():
+    contexts = get_all_market_contexts()
+    assert "primary" in contexts
+    assert "deployment" in contexts
+    assert "default" not in contexts
+    assert contexts["primary"].database_alias == "wcmktprod"
+    assert contexts["deployment"].database_alias == "wcmktnorth"
+
+
+def test_get_all_characters_returns_configured_characters():
+    chars = get_all_characters()
+    names = {c.name for c in chars}
+    assert "Orthel Toralen" in names
+
+
+def test_market_data_legacy_falls_back_to_markets_section():
+    """When [market_data] is missing/empty, derive from [markets.*]."""
+    fake = {
+        "markets": {
+            "primary": {
+                "name": "Primary",
+                "region_id": 1,
+                "system_id": 2,
+                "structure_id": 3,
+            },
+            "deployment": {
+                "name": "Deployment",
+                "region_id": 4,
+                "system_id": 5,
+                "structure_id": 6,
+            },
+        },
+    }
+    s = SettingsService.__new__(SettingsService)
+    s.settings = fake
+    md = s.get_market_data_legacy()
+    assert md["primary_region_id"] == 1
+    assert md["deployment_structure_id"] == 6
+    assert md["primary_market_name"] == "Primary"

--- a/tests/test_verify_db_exists.py
+++ b/tests/test_verify_db_exists.py
@@ -24,7 +24,7 @@ class TestVerifyDbExists:
     @pytest.fixture
     def mock_db_config(self, temp_db_path):
         """Create a DatabaseConfig with mocked sync and temp path."""
-        from mkts_backend.config.config import DatabaseConfig
+        from mkts_backend.config.db_config import DatabaseConfig
 
         with patch.object(DatabaseConfig, '__init__', lambda self, *args, **kwargs: None):
             db = DatabaseConfig()
@@ -172,7 +172,7 @@ class TestNeedsInit:
 
     @pytest.fixture
     def mock_db_config(self, temp_db_path):
-        from mkts_backend.config.config import DatabaseConfig
+        from mkts_backend.config.db_config import DatabaseConfig
 
         with patch.object(DatabaseConfig, '__init__', lambda self, *args, **kwargs: None):
             db = DatabaseConfig()
@@ -241,7 +241,7 @@ class TestNukeMethods:
 
     @pytest.fixture
     def mock_db_config(self, temp_db_path):
-        from mkts_backend.config.config import DatabaseConfig
+        from mkts_backend.config.db_config import DatabaseConfig
 
         with patch.object(DatabaseConfig, '__init__', lambda self, *args, **kwargs: None):
             db = DatabaseConfig()
@@ -346,7 +346,7 @@ class TestConfirmMetadataExists:
 
     @pytest.fixture
     def mock_db_config(self, temp_db_path):
-        from mkts_backend.config.config import DatabaseConfig
+        from mkts_backend.config.db_config import DatabaseConfig
 
         with patch.object(DatabaseConfig, '__init__', lambda self, *args, **kwargs: None):
             db = DatabaseConfig()
@@ -379,7 +379,7 @@ class TestReadDbInfo:
 
     @pytest.fixture
     def mock_db_config(self, temp_db_path):
-        from mkts_backend.config.config import DatabaseConfig
+        from mkts_backend.config.db_config import DatabaseConfig
 
         with patch.object(DatabaseConfig, '__init__', lambda self, *args, **kwargs: None):
             db = DatabaseConfig()
@@ -416,7 +416,7 @@ class TestIntegrationScenarios:
 
     @pytest.fixture
     def mock_db_config(self, temp_db_path):
-        from mkts_backend.config.config import DatabaseConfig
+        from mkts_backend.config.db_config import DatabaseConfig
 
         with patch.object(DatabaseConfig, '__init__', lambda self, *args, **kwargs: None):
             db = DatabaseConfig()


### PR DESCRIPTION
## Summary

- Replace four independent `tomllib` loaders with a single `SettingsService` (module-level cache, `MKTS_ENVIRONMENT` override, typed accessors, domain helpers).
- Add `[wipe_replace]` to `settings.toml`; `db_handlers.py` now reads the wipe-replace table list from TOML instead of hardcoding it.
- Rename `config/config.py` → `config/db_config.py` (file only held `DatabaseConfig`; old name was misleading). All ~50 call sites updated.
- `get_market_data_legacy()` derives flat keys from `[markets.*]` when `[market_data]` is absent, fixing a latent import-time `KeyError`.

## Why

`settings.toml` was being parsed in four different files, each maintaining its own caching, env-override, and legacy-fallback logic. Every TOML schema change had to touch all four. This PR funnels reads through one service so the next schema change is a single-file edit. The `config.py` rename clarifies that the file is database-specific, not a general config module.

## Test plan

- [x] `uv run pytest tests/` — 337 passed (was 321 + 9 stale-data failures + 7 new service tests)
- [x] `uv run mkts-backend --list-markets` — loads both markets correctly
- [x] Grep guards: no `from mkts_backend.config.config` imports remain; `tomllib` only in `settings_service.py`; no orphan `load_settings`/`settings_file` references.
- [x] 9 pre-existing test failures (stale data from commit 1253036, X47 deployment switch) updated to match current TOML.

## Follow-up

`AGENTS.md` documents a TOML-structure table; a memory note flags the parallel-paths cleanup (`[markets.*]` / `[db]` legacy aliases / `[market_data]`) for a future refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)