### PR TITLE
fix(config): make SettingsService.environment dynamic so --env=<env> works after import

### DIFF
--- a/src/mkts_backend/cli.py
+++ b/src/mkts_backend/cli.py
@@ -435,7 +435,7 @@ def _run_market_pipeline(
         logger.error("Failed to update doctrines")
         exit()
 
-    env = os.environ.get("MKTS_ENVIRONMENT", settings["app"]["environment"])
+    env = SettingsService().environment
 
     # Update Google Sheets if enabled and primary market
     if (

--- a/src/mkts_backend/config/db_config.py
+++ b/src/mkts_backend/config/db_config.py
@@ -90,10 +90,10 @@ class DatabaseConfig:
             self.token = market_context.turso_token
             logger.info(f"DatabaseConfig initialized from MarketContext: {market_context.name}")
         else:
-            # SettingsService already applied MKTS_ENVIRONMENT override at load
-            # time — re-reading os.environ here would let the two configs drift
-            # if env was changed mid-process.
-            env = self.settings["app"]["environment"]
+            # Use the property so MKTS_ENVIRONMENT set by --env=<env> after
+            # module import is still picked up. Reading self.settings directly
+            # would freeze on the cached TOML default.
+            env = SettingsService().environment
             if env == 'development':
                 alias = self._testing_db_alias
             elif alias is None or alias in ["wcmkt", "primary", "wcmktprod"]:

--- a/src/mkts_backend/config/settings_service.py
+++ b/src/mkts_backend/config/settings_service.py
@@ -31,13 +31,16 @@ _cached_settings: dict | None = None
 
 
 def _load_settings(path: Optional[Path] = None) -> dict:
-    """Load and cache settings from the TOML file.
+    """Load and cache the TOML file as-is.
 
-    Default path: cached on first call. ``MKTS_ENVIRONMENT`` is read at that
-    first load and frozen — call :func:`clear_cache` to refresh.
+    The cached dict is the raw TOML — runtime overlays (notably
+    ``MKTS_ENVIRONMENT``) are NOT baked in here. Consumers that need the
+    runtime-effective value should go through :class:`SettingsService`'s
+    typed properties (e.g. ``service.environment``), which read env vars
+    at access time. This lets a CLI flag set after import still take effect.
 
-    Explicit path: bypasses the cache entirely and never populates it. Tests
-    that swap fixtures don't poison the singleton.
+    Default path: cached on first call.
+    Explicit path: bypasses the cache entirely and never populates it.
     """
     global _cached_settings
     if path is not None:
@@ -51,20 +54,13 @@ def _load_settings(path: Optional[Path] = None) -> dict:
 def _read_settings_file(settings_path: Path) -> dict:
     try:
         with open(settings_path, "rb") as f:
-            settings = tomllib.load(f)
+            return tomllib.load(f)
     except Exception as e:
         # Logging may not yet be configured at this bootstrap point — write
         # to stderr so the user sees the failure even before configure_logging.
         sys.stderr.write(f"FATAL: Failed to load settings from {settings_path}: {e}\n")
         logger.error("Failed to load settings from %s: %s", settings_path, e)
         raise
-
-    env_override = os.environ.get("MKTS_ENVIRONMENT")
-    if env_override and "app" in settings:
-        logger.info("Environment overridden by MKTS_ENVIRONMENT: %s", env_override)
-        settings["app"] = {**settings["app"], "environment": env_override}
-
-    return settings
 
 
 def clear_cache() -> None:
@@ -98,7 +94,14 @@ class SettingsService:
 
     @property
     def environment(self) -> str:
-        return self.settings["app"]["environment"]
+        """Resolved runtime environment.
+
+        Returns ``MKTS_ENVIRONMENT`` if set, else the TOML ``app.environment``.
+        Read on every access — a ``--env=development`` CLI flag that sets the
+        env var after module imports still takes effect for downstream
+        consumers like ``MarketContext.from_settings()``.
+        """
+        return os.environ.get("MKTS_ENVIRONMENT", self.settings["app"]["environment"])
 
     @property
     def log_level(self) -> str:

--- a/tests/test_settings_service.py
+++ b/tests/test_settings_service.py
@@ -151,14 +151,20 @@ def test_market_data_legacy_raises_when_required_id_missing():
         s.get_market_data_legacy()
 
 
-def test_environment_override_frozen_after_first_load(monkeypatch):
-    """Document the freeze: env changed after first load is ignored."""
+def test_environment_override_applies_after_first_load(monkeypatch):
+    """env var set AFTER cache priming must still take effect.
+
+    Regression guard: previously the env override was baked into the cached
+    dict at first load, so a CLI flag like ``--env=development`` that sets
+    MKTS_ENVIRONMENT after module imports was silently ignored — primary
+    market routed to the production DB instead of testing.
+    """
     monkeypatch.setenv("MKTS_ENVIRONMENT", "production")
     clear_cache()
-    SettingsService()  # first load — freezes env=production
+    SettingsService()  # primes cache while env=production
     monkeypatch.setenv("MKTS_ENVIRONMENT", "development")
-    # No clear_cache — production is still frozen in.
-    assert SettingsService().environment == "production"
+    # No clear_cache — but environment property now reads env dynamically.
+    assert SettingsService().environment == "development"
 
 
 def test_environment_override_unset_falls_back_to_toml(monkeypatch):
@@ -167,6 +173,29 @@ def test_environment_override_unset_falls_back_to_toml(monkeypatch):
     s = SettingsService()
     # The TOML default is "production"; if you change it, update this assertion.
     assert s.environment == "production"
+
+
+def test_market_context_picks_up_late_env_override(monkeypatch):
+    """End-to-end regression: simulate the --env=development CLI path.
+
+    Order matches what cli.py does in practice:
+    1. Modules import → SettingsService() runs at module load (cache primed
+       with env=production from TOML).
+    2. parse_args() sets os.environ["MKTS_ENVIRONMENT"] = "development".
+    3. MarketContext.from_settings("primary") is called downstream.
+
+    Before the fix this returned the production DB; after, it returns
+    the testing DB because environment is read dynamically.
+    """
+    from mkts_backend.config.market_context import MarketContext
+
+    monkeypatch.delenv("MKTS_ENVIRONMENT", raising=False)
+    clear_cache()
+    SettingsService()  # simulate import-time priming with env unset
+
+    monkeypatch.setenv("MKTS_ENVIRONMENT", "development")  # simulate --env=development
+    ctx = MarketContext.from_settings("primary")
+    assert ctx.database_alias == "wcmkttest"
 
 
 def test_get_all_characters_requires_char_id(monkeypatch):


### PR DESCRIPTION
## Summary
- `mkts-backend --env=development` was a silent no-op for `MarketContext`: primary writes routed to production DB unless `MKTS_ENVIRONMENT` was set in the parent shell.
- Module-import-time `SettingsService()` calls (in `logging_config`, `esi_config`, `db_config` class body, `cli.py:38`) primed the cache with the env override baked in. Since `MKTS_ENVIRONMENT` was unset at that point, `app.environment` froze as the TOML default. `parse_args` then set the env var — too late, cache was frozen.
- Fix: cache holds raw TOML only; `SettingsService.environment` reads `os.environ` at every access. `db_config` and `cli.py` route through the property so all consumers agree on the same dynamic value.

## Why this is a regression from the prior `settings_service` PR
The C4 fix in that PR (#28) replaced `db_config`'s runtime `os.environ.get(...)` with the cached dict value for "consistency" with `MarketContext`. That actually made things worse — pre-C4, `--env` still worked for `db_config` even while `MarketContext` was broken. Unifying both on the cached path made `--env` a complete no-op.

## Test plan
- [x] `uv run pytest` — 348 passed, 0 failed
- [x] End-to-end smoke: import primes cache (env=production), then set `MKTS_ENVIRONMENT=development`, then call `MarketContext.from_settings("primary")` → returns `database_alias="wcmkttest"` (was `wcmktprod` before fix)
- [x] New regression test `test_market_context_picks_up_late_env_override` matches the exact CLI ordering (import → env-set → `from_settings`) and asserts the testing DB
- [x] Inverted `test_environment_override_frozen_after_first_load` → `test_environment_override_applies_after_first_load` — the previous test was documenting the bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)