### PR TITLE
fix: guard duplicate watchlist entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ curl-request.txt
 target_updates.sql
 factionmap.sql mktcheck.sql target_updates.sql
 *.sql
+dbrefresh.sh

--- a/scripts/repair_prod_schema.py
+++ b/scripts/repair_prod_schema.py
@@ -1,0 +1,239 @@
+"""Repair production schema by replacing pandas-shaped tables with Base-shaped ones.
+
+Targets (cloud Turso DBs):
+  - wcmktprod.marketstats  (no PK, BIGINT types)
+  - wcmktprod.watchlist    (no PK, BIGINT types)
+  - wcmktnorth.watchlist   (no PK, INT types)
+
+Each target is migrated by:
+  1. CSV backup of current rows
+  2. CREATE TABLE <t>_new (Base schema)
+  3. INSERT INTO <t>_new SELECT ... FROM <t> (with COALESCE for NOT NULL)
+  4. DROP TABLE <t>; ALTER TABLE <t>_new RENAME TO <t>
+  5. Verify row count and PK presence
+
+Dry-run by default. Pass --apply to actually write.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pandas as pd
+from sqlalchemy import text
+from sqlalchemy.schema import CreateTable
+
+from mkts_backend.config.db_config import DatabaseConfig
+from mkts_backend.config.logging_config import configure_logging
+from mkts_backend.db.models import MarketStats, Watchlist, Base
+
+logger = configure_logging(__name__)
+
+BACKUP_DIR = Path("data/migration_backups")
+
+
+# (alias, table_name, model)
+TARGETS = [
+    ("wcmktprod", "marketstats", MarketStats),
+    ("wcmktprod", "watchlist", Watchlist),
+    ("wcmktnorth", "watchlist", Watchlist),
+]
+
+
+# Per-table COALESCE expressions to fill any nulls when copying from the old
+# pandas-shaped table into the new NOT NULL Base-shaped table.
+DEFAULTS = {
+    "marketstats": {
+        "type_id": "0",
+        "total_volume_remain": "0",
+        "min_price": "0.0",
+        "price": "0.0",
+        "avg_price": "0.0",
+        "avg_volume": "0.0",
+        "group_id": "0",
+        "type_name": "''",
+        "group_name": "''",
+        "category_id": "0",
+        "category_name": "''",
+        "days_remaining": "0.0",
+        "last_update": "CURRENT_TIMESTAMP",
+    },
+    "watchlist": {
+        "type_id": "0",
+        "group_id": "0",
+        "type_name": "''",
+        "group_name": "''",
+        "category_id": "0",
+        "category_name": "''",
+    },
+}
+
+
+def backup_table(db: DatabaseConfig, table: str) -> Path:
+    BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    out = BACKUP_DIR / f"{db.alias}_{table}_{ts}.csv"
+    with db.remote_engine.connect() as conn:
+        df = pd.read_sql_query(f"SELECT * FROM {table}", conn)
+    df.to_csv(out, index=False)
+    logger.info(f"Backed up {len(df)} rows from {db.alias}.{table} -> {out}")
+    return out
+
+
+def get_pk_cols(db: DatabaseConfig, table: str, remote: bool = True) -> list[str]:
+    engine = db.remote_engine if remote else db.engine
+    with engine.connect() as conn:
+        rows = conn.execute(text(f"PRAGMA table_info({table})")).fetchall()
+    return [r.name for r in rows if r.pk]
+
+
+def row_count(db: DatabaseConfig, table: str) -> int:
+    with db.remote_engine.connect() as conn:
+        return conn.execute(text(f"SELECT COUNT(*) FROM {table}")).scalar()
+
+
+def duplicate_type_ids(db: DatabaseConfig, table: str) -> list[tuple]:
+    with db.remote_engine.connect() as conn:
+        return conn.execute(
+            text(
+                f"SELECT type_id, COUNT(*) c FROM {table} "
+                f"GROUP BY type_id HAVING c>1"
+            )
+        ).fetchall()
+
+
+def build_select_expr(table: str, source: str) -> str:
+    """Build a SELECT list with COALESCE for each Base column."""
+    defaults = DEFAULTS[table]
+    cols = list(defaults.keys())
+    pieces = [f"COALESCE({source}.{c}, {defaults[c]}) AS {c}" for c in cols]
+    return ", ".join(pieces), cols
+
+
+def migrate_target(db: DatabaseConfig, table: str, model, *, apply: bool) -> bool:
+    print(f"\n=== {db.alias}.{table} ===")
+    pk_before = get_pk_cols(db, table)
+    rows_before = row_count(db, table)
+    dups_before = duplicate_type_ids(db, table)
+    print(f"Before: rows={rows_before}, pk={pk_before}, duplicates={len(dups_before)}")
+
+    if pk_before == ["type_id"]:
+        print("Already has PK on type_id — nothing to do.")
+        return True
+
+    if dups_before:
+        print(f"REFUSING: {len(dups_before)} duplicate type_ids in source table.")
+        print(f"   {dups_before[:5]}{' …' if len(dups_before) > 5 else ''}")
+        return False
+
+    backup = backup_table(db, table)
+    print(f"Backup written: {backup}")
+
+    select_expr, cols = build_select_expr(table, "src")
+    column_list = ", ".join(cols)
+    new_table = f"{table}_new"
+
+    # Build CREATE TABLE statement from the SQLAlchemy model. Use sqlite dialect
+    # since libsql speaks SQLite. Substitute the table name to <t>_new.
+    ddl = str(
+        CreateTable(model.__table__).compile(
+            dialect=db.remote_engine.dialect
+        )
+    ).strip().rstrip(";")
+    ddl = ddl.replace(f"CREATE TABLE {table}", f"CREATE TABLE {new_table}", 1)
+
+    print(f"\nDDL for new table:\n{ddl}")
+    print(f"\nINSERT plan:\n  INSERT INTO {new_table} ({column_list})")
+    print(f"  SELECT {select_expr} FROM {table} src;")
+
+    if not apply:
+        print("\nDRY RUN — no changes made. Pass --apply to execute.")
+        return True
+
+    # Execute migration as a single transaction.
+    engine = db.remote_engine
+    with engine.begin() as conn:
+        # Defensive: drop any leftover *_new from a previous failed run.
+        conn.execute(text(f"DROP TABLE IF EXISTS {new_table}"))
+        conn.execute(text(ddl))
+        conn.execute(
+            text(
+                f"INSERT INTO {new_table} ({column_list}) "
+                f"SELECT {select_expr} FROM {table} src"
+            )
+        )
+        copied = conn.execute(
+            text(f"SELECT COUNT(*) FROM {new_table}")
+        ).scalar()
+        if copied != rows_before:
+            raise RuntimeError(
+                f"Row count mismatch after copy: src={rows_before}, new={copied}"
+            )
+        conn.execute(text(f"DROP TABLE {table}"))
+        conn.execute(text(f"ALTER TABLE {new_table} RENAME TO {table}"))
+
+    pk_after = get_pk_cols(db, table)
+    rows_after = row_count(db, table)
+    print(f"After:  rows={rows_after}, pk={pk_after}")
+
+    if pk_after != ["type_id"]:
+        print(f"FAIL: PK not present after migration. Got {pk_after}")
+        return False
+    if rows_after != rows_before:
+        print(f"FAIL: row count drift: before={rows_before}, after={rows_after}")
+        return False
+    print("OK")
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually run the migration. Default is dry-run.",
+    )
+    parser.add_argument(
+        "--only",
+        action="append",
+        metavar="alias.table",
+        help="Restrict to a single target, e.g. --only wcmktprod.watchlist. "
+        "Repeatable.",
+    )
+    args = parser.parse_args()
+
+    targets = TARGETS
+    if args.only:
+        wanted = set(args.only)
+        targets = [t for t in TARGETS if f"{t[0]}.{t[1]}" in wanted]
+        if not targets:
+            print(f"No matching targets for {args.only}. Available: "
+                  f"{[f'{a}.{t}' for a, t, _ in TARGETS]}")
+            return 2
+
+    print(f"Mode: {'APPLY' if args.apply else 'DRY-RUN'}")
+    print(f"Targets: {[f'{a}.{t}' for a, t, _ in targets]}")
+
+    failed = []
+    for alias, table, model in targets:
+        db = DatabaseConfig(alias)
+        try:
+            ok = migrate_target(db, table, model, apply=args.apply)
+            if not ok:
+                failed.append(f"{alias}.{table}")
+        except Exception as e:
+            logger.exception(f"Migration failed for {alias}.{table}")
+            print(f"EXCEPTION on {alias}.{table}: {e}")
+            failed.append(f"{alias}.{table}")
+
+    if failed:
+        print(f"\nFAILED: {failed}")
+        return 1
+    print("\nAll targets OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repair_prod_schema.py
+++ b/scripts/repair_prod_schema.py
@@ -104,7 +104,7 @@ def duplicate_type_ids(db: DatabaseConfig, table: str) -> list[tuple]:
         ).fetchall()
 
 
-def build_select_expr(table: str, source: str) -> str:
+def build_select_expr(table: str, source: str) -> tuple[str, list[str]]:
     """Build a SELECT list with COALESCE for each Base column."""
     defaults = DEFAULTS[table]
     cols = list(defaults.keys())

--- a/src/mkts_backend/utils/db_utils.py
+++ b/src/mkts_backend/utils/db_utils.py
@@ -1,5 +1,6 @@
 import pandas as pd
-from sqlalchemy import text, insert, select, bindparam
+from sqlalchemy import text, select, bindparam
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from mkts_backend.config.db_config import DatabaseConfig
 from mkts_backend.config.logging_config import configure_logging
 from mkts_backend.db.models import Watchlist, UpdateLog
@@ -72,19 +73,19 @@ def add_missing_items_to_watchlist(missing_items: list[int], remote: bool = Fals
 
         with engine.connect() as conn:
             for _, row in new_items.iterrows():
-                stmt = insert(Watchlist).values(
-                    type_id=row['type_id'],
+                stmt = sqlite_insert(Watchlist).values(
+                    type_id=int(row['type_id']),
                     type_name=row['type_name'],
-                    group_id=row['group_id'],
+                    group_id=int(row['group_id']),
                     group_name=row['group_name'],
-                    category_id=row['category_id'],
+                    category_id=int(row['category_id']),
                     category_name=row['category_name']
-                )
-                try:
-                    conn.execute(stmt)
+                ).on_conflict_do_nothing(index_elements=["type_id"])
+                result = conn.execute(stmt)
+                if result.rowcount:
                     logger.info(f"Added {row['type_name']} (ID: {row['type_id']}) to watchlist")
-                except Exception as e:
-                    logger.warning(f"Item {row['type_id']} may already exist: {e}")
+                else:
+                    logger.info(f"Skipped {row['type_name']} (ID: {row['type_id']}): already in watchlist")
             conn.commit()
 
         engine.dispose()
@@ -118,22 +119,21 @@ def update_watchlist_tables(missing_items: list[int]):
     df = df.rename(columns=dict(zip(inv_cols, watchlist_cols)))
 
     engine = wcmkt_db.engine
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         for _, row in df.iterrows():
-            stmt = insert(Watchlist).values(
-                type_id=row['type_id'],
+            stmt = sqlite_insert(Watchlist).values(
+                type_id=int(row['type_id']),
                 type_name=row['type_name'],
-                group_id=row['group_id'],
+                group_id=int(row['group_id']),
                 group_name=row['group_name'],
-                category_id=row['category_id'],
+                category_id=int(row['category_id']),
                 category_name=row['category_name']
-            )
-            try:
-                conn.execute(stmt)
-                conn.commit()
+            ).on_conflict_do_nothing(index_elements=["type_id"])
+            result = conn.execute(stmt)
+            if result.rowcount:
                 logger.info(f"Added {row['type_name']} (ID: {row['type_id']}) to watchlist")
-            except Exception as e:
-                logger.warning(f"Item {row['type_id']} may already exist in watchlist: {e}")
+            else:
+                logger.info(f"Skipped {row['type_name']} (ID: {row['type_id']}): already in watchlist")
 
 def export_doctrines_to_csv(db_alias: str = "wcmkt", output_file: str = "doctrines_backup.csv"):
     """
@@ -278,14 +278,23 @@ def fix_null_doctrine_stats_timestamps (doctrine_stats: pd.DataFrame, timestamp:
 
 def restore_watchlist_from_csv(csv_file: str = "data/watchlist_updated.csv", remote: bool = False):
 
+    cols = ["type_id", "type_name", "group_id", "group_name", "category_id", "category_name"]
+    df = pd.read_csv(csv_file)[cols]
+    df["type_id"] = df["type_id"].astype(int)
+    df["group_id"] = df["group_id"].astype(int)
+    df["category_id"] = df["category_id"].astype(int)
+    rows = df.to_dict(orient="records")
+
     db = DatabaseConfig("wcmkt")
     engine = db.remote_engine if remote else db.engine
-    with engine.connect() as conn:
-        df = pd.read_csv(csv_file)
-        df.to_sql("watchlist", conn, if_exists="replace", index=False)
-    conn.close()
-    engine.dispose()
-    logger.info(f"Restored watchlist from {csv_file} to {db.alias}")
+    try:
+        with engine.begin() as conn:
+            conn.execute(text("DELETE FROM watchlist"))
+            for i in range(0, len(rows), 500):
+                conn.execute(sqlite_insert(Watchlist).values(rows[i : i + 500]))
+    finally:
+        engine.dispose()
+    logger.info(f"Restored watchlist from {csv_file} to {db.alias}: {len(df)} items")
 
 if __name__ == "__main__":
     pass

--- a/src/mkts_backend/utils/db_utils.py
+++ b/src/mkts_backend/utils/db_utils.py
@@ -285,6 +285,12 @@ def restore_watchlist_from_csv(csv_file: str = "data/watchlist_updated.csv", rem
     df["category_id"] = df["category_id"].astype(int)
     rows = df.to_dict(orient="records")
 
+    if not rows:
+        raise ValueError(
+            f"refusing to restore watchlist from empty CSV {csv_file}: "
+            "would DELETE all rows and insert nothing"
+        )
+
     db = DatabaseConfig("wcmkt")
     engine = db.remote_engine if remote else db.engine
     try:

--- a/src/mkts_backend/utils/doctrine_update.py
+++ b/src/mkts_backend/utils/doctrine_update.py
@@ -4,9 +4,10 @@ from typing import List
 
 import pandas as pd
 from sqlalchemy import text, select
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.orm import Session
 
-from mkts_backend.db.models import Doctrines, LeadShips, DoctrineFitItems, Base
+from mkts_backend.db.models import Doctrines, LeadShips, DoctrineFitItems, Watchlist, Base
 from mkts_backend.db.db_queries import get_watchlist_ids, get_fit_ids, get_fit_items
 from mkts_backend.utils.get_type_info import TypeInfo
 from mkts_backend.config.db_config import DatabaseConfig
@@ -1046,16 +1047,25 @@ def add_doctrine_type_info_to_watchlist(doctrine_id: int):
                 missing_type_info.append(type_info)
 
     for type_info in missing_type_info:
-        stmt5 = text("INSERT INTO watchlist (type_id, type_name, group_name, category_name, category_id, group_id) VALUES (:type_id, :type_name, :group_name, :category_name, :category_id, :group_id)")
+        stmt5 = sqlite_insert(Watchlist).values(
+            type_id=int(type_info.type_id),
+            type_name=type_info.type_name,
+            group_name=type_info.group_name,
+            category_name=type_info.category_name,
+            category_id=int(type_info.category_id),
+            group_id=int(type_info.group_id),
+        ).on_conflict_do_nothing(index_elements=["type_id"])
         db = DatabaseConfig("wcmkt")
         engine = db.engine
-        with engine.connect() as conn:
-            conn.execute(stmt5, {"type_id": type_info.type_id, "type_name": type_info.type_name, "group_name": type_info.group_name, "category_name": type_info.category_name, "category_id": type_info.category_id, "group_id": type_info.group_id})
-            conn.commit()
-        conn.close()
+        with engine.begin() as conn:
+            result = conn.execute(stmt5)
         engine.dispose()
-        logger.info(f"Added {type_info.type_name} to watchlist")
-        print(f"Added {type_info.type_name} to watchlist")
+        if result.rowcount:
+            logger.info(f"Added {type_info.type_name} to watchlist")
+            print(f"Added {type_info.type_name} to watchlist")
+        else:
+            logger.info(f"Skipped {type_info.type_name}: already in watchlist")
+            print(f"Skipped {type_info.type_name}: already in watchlist")
 
 def refresh_doctrines_for_fit(fit_id: int, ship_id: int, ship_name: str, remote: bool = False, db_alias: str = "wcmkt", engine=None, conn=None) -> None:
     """

--- a/src/mkts_backend/utils/utils.py
+++ b/src/mkts_backend/utils/utils.py
@@ -153,6 +153,12 @@ def update_watchlist_data(esi: ESIConfig, watchlist_csv: str = "data/watchlist.c
     df["category_id"] = df["category_id"].astype(int)
     rows = df.to_dict(orient="records")
 
+    if not rows:
+        raise ValueError(
+            f"refusing to update watchlist from empty CSV {watchlist_csv}: "
+            "would DELETE all rows and insert nothing"
+        )
+
     engine = wcmkt_db.engine
     with engine.begin() as conn:
         conn.execute(text("DELETE FROM watchlist"))

--- a/src/mkts_backend/utils/utils.py
+++ b/src/mkts_backend/utils/utils.py
@@ -6,9 +6,11 @@ import pandas as pd
 import json
 import sqlalchemy as sa
 from sqlalchemy import text, create_engine
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from mkts_backend.config.db_config import DatabaseConfig
 from mkts_backend.config.esi_config import ESIConfig
 from mkts_backend.config.logging_config import configure_logging
+from mkts_backend.db.models import Watchlist
 from sqlalchemy.orm import Session
 from datetime import datetime, timezone
 logger = configure_logging(__name__)
@@ -144,13 +146,18 @@ def get_fit_items(fit_id: int) -> pd.DataFrame:
     return df
 
 def update_watchlist_data(esi: ESIConfig, watchlist_csv: str = "data/watchlist.csv") -> bool:
-    df = pd.read_csv(watchlist_csv)
-    db = wcmkt_db
-    engine = db.engine
-    with engine.connect() as conn:
-        df.to_sql("watchlist", conn, if_exists="replace", index=False)
-        conn.commit()
-    conn.close()
+    cols = ["type_id", "type_name", "group_id", "group_name", "category_id", "category_name"]
+    df = pd.read_csv(watchlist_csv)[cols]
+    df["type_id"] = df["type_id"].astype(int)
+    df["group_id"] = df["group_id"].astype(int)
+    df["category_id"] = df["category_id"].astype(int)
+    rows = df.to_dict(orient="records")
+
+    engine = wcmkt_db.engine
+    with engine.begin() as conn:
+        conn.execute(text("DELETE FROM watchlist"))
+        for i in range(0, len(rows), 500):
+            conn.execute(sqlite_insert(Watchlist).values(rows[i : i + 500]))
     logger.info(f"Watchlist updated: {len(df)} items")
     return True
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,6 +9,9 @@ from unittest.mock import patch, MagicMock, call
 import pandas as pd
 import sqlite3
 from pathlib import Path
+from sqlalchemy import create_engine
+
+from mkts_backend.db.models import Base
 
 
 class TestFullMarketContextFlow:
@@ -93,10 +96,11 @@ class TestDatabaseWriteIsolation:
         primary_db_path = temp_db_dir / "wcmktprod.db"
         deployment_db_path = temp_db_dir / "wcmktnorth2.db"
 
-        # Write to primary database
-        conn_primary = sqlite3.connect(str(primary_db_path))
-        test_data.to_sql("marketstats", conn_primary, if_exists="replace", index=False)
-        conn_primary.close()
+        primary_engine = create_engine(f"sqlite:///{primary_db_path}")
+        Base.metadata.create_all(primary_engine)
+        with primary_engine.begin() as conn:
+            test_data.to_sql("marketstats", conn, if_exists="append", index=False)
+        primary_engine.dispose()
 
         # Read from deployment database - should NOT have the data
         conn_deployment = sqlite3.connect(str(deployment_db_path))

--- a/tests/test_repair_prod_schema.py
+++ b/tests/test_repair_prod_schema.py
@@ -1,0 +1,218 @@
+"""Tests for the prod schema repair migration.
+
+The migration drops/recreates production tables with PK constraints
+restored, copying rows via COALESCE to fill NULLs left over from the
+pandas-replace era. These tests pin the contract: PK after, row count
+preserved, NULLs filled, idempotent on already-correct tables, and
+refusing on duplicate type_ids.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from mkts_backend.db.models import Base, Watchlist, MarketStats
+
+
+def _load_repair_module():
+    """Load scripts/repair_prod_schema.py as a module without scripts being a package."""
+    src = Path(__file__).resolve().parent.parent / "scripts" / "repair_prod_schema.py"
+    spec = importlib.util.spec_from_file_location("repair_prod_schema", src)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["repair_prod_schema"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+repair = _load_repair_module()
+
+
+class _FakeDB:
+    def __init__(self, engine, alias: str = "fake"):
+        self.engine = engine
+        self.remote_engine = engine
+        self.alias = alias
+
+
+def _make_pandas_shape_watchlist(engine, rows: list[dict]) -> None:
+    """Recreate the broken (no-PK, pandas-shaped) watchlist that the
+    migration is designed to repair.
+    """
+    with engine.begin() as conn:
+        conn.execute(text("DROP TABLE IF EXISTS watchlist"))
+        conn.execute(text(
+            "CREATE TABLE watchlist ("
+            "type_id BIGINT, type_name TEXT, "
+            "group_id BIGINT, group_name TEXT, "
+            "category_id BIGINT, category_name TEXT)"
+        ))
+        for row in rows:
+            conn.execute(
+                text(
+                    "INSERT INTO watchlist (type_id, type_name, group_id, "
+                    "group_name, category_id, category_name) "
+                    "VALUES (:type_id, :type_name, :group_id, :group_name, "
+                    ":category_id, :category_name)"
+                ),
+                row,
+            )
+
+
+@pytest.fixture
+def fake_db(tmp_path, monkeypatch):
+    engine = create_engine(f"sqlite:///{tmp_path}/repair.db")
+    monkeypatch.setattr(repair, "BACKUP_DIR", tmp_path / "backups")
+    yield _FakeDB(engine, alias="testdb")
+    engine.dispose()
+
+
+# ---- build_select_expr returns a tuple --------------------------------------
+
+
+def test_build_select_expr_returns_tuple_of_str_and_columns():
+    expr, cols = repair.build_select_expr("watchlist", "src")
+    assert isinstance(expr, str)
+    assert isinstance(cols, list)
+    assert "type_id" in cols
+    assert "COALESCE(src.type_id" in expr
+
+
+# ---- migrate_target end-to-end ----------------------------------------------
+
+
+def test_migrate_target_restores_pk_and_preserves_rows(fake_db):
+    _make_pandas_shape_watchlist(fake_db.engine, [
+        {"type_id": 1, "type_name": "a", "group_id": 10,
+         "group_name": "g", "category_id": 100, "category_name": "c"},
+        {"type_id": 2, "type_name": "b", "group_id": 20,
+         "group_name": "g", "category_id": 200, "category_name": "c"},
+    ])
+
+    ok = repair.migrate_target(fake_db, "watchlist", Watchlist, apply=True)
+
+    assert ok is True
+    pk_after = repair.get_pk_cols(fake_db, "watchlist")
+    assert pk_after == ["type_id"]
+    with fake_db.engine.connect() as conn:
+        ids = conn.execute(text("SELECT type_id FROM watchlist ORDER BY type_id")).fetchall()
+    assert [r.type_id for r in ids] == [1, 2]
+
+
+def test_migrate_target_is_idempotent_on_already_repaired_table(fake_db):
+    """Calling migrate_target on a table that already has the correct PK
+    must short-circuit and not touch the data.
+    """
+    Base.metadata.tables["watchlist"].create(fake_db.engine)
+    with fake_db.engine.begin() as conn:
+        conn.execute(text(
+            "INSERT INTO watchlist (type_id, type_name, group_id, group_name, "
+            "category_id, category_name) "
+            "VALUES (1, 'a', 10, 'g', 100, 'c')"
+        ))
+
+    ok = repair.migrate_target(fake_db, "watchlist", Watchlist, apply=True)
+
+    assert ok is True
+    with fake_db.engine.connect() as conn:
+        rows = conn.execute(text("SELECT type_id, type_name FROM watchlist")).fetchall()
+    assert [(r.type_id, r.type_name) for r in rows] == [(1, "a")]
+
+
+def test_migrate_target_refuses_when_source_has_duplicate_type_ids(fake_db):
+    """If the broken table contains duplicate type_ids, the migration
+    must refuse rather than crash on PK collision mid-copy.
+    """
+    _make_pandas_shape_watchlist(fake_db.engine, [
+        {"type_id": 1, "type_name": "a", "group_id": 10,
+         "group_name": "g", "category_id": 100, "category_name": "c"},
+        {"type_id": 1, "type_name": "duplicate", "group_id": 10,
+         "group_name": "g", "category_id": 100, "category_name": "c"},
+    ])
+
+    ok = repair.migrate_target(fake_db, "watchlist", Watchlist, apply=True)
+
+    assert ok is False
+    pk_after = repair.get_pk_cols(fake_db, "watchlist")
+    assert pk_after == [], "table must be unchanged when refused"
+
+
+def test_migrate_target_dry_run_does_not_write(fake_db):
+    """apply=False prints the plan and returns True, but the broken
+    schema must remain unchanged.
+    """
+    _make_pandas_shape_watchlist(fake_db.engine, [
+        {"type_id": 1, "type_name": "a", "group_id": 10,
+         "group_name": "g", "category_id": 100, "category_name": "c"},
+    ])
+
+    ok = repair.migrate_target(fake_db, "watchlist", Watchlist, apply=False)
+
+    assert ok is True
+    pk_after = repair.get_pk_cols(fake_db, "watchlist")
+    assert pk_after == [], "dry-run must not modify the schema"
+
+
+def test_migrate_target_fills_nulls_via_coalesce(fake_db):
+    """A NULL in a source column that maps to a NOT NULL Base column
+    must be replaced with the documented DEFAULTS value, not abort the
+    migration.
+    """
+    with fake_db.engine.begin() as conn:
+        conn.execute(text("DROP TABLE IF EXISTS watchlist"))
+        conn.execute(text(
+            "CREATE TABLE watchlist ("
+            "type_id BIGINT, type_name TEXT, "
+            "group_id BIGINT, group_name TEXT, "
+            "category_id BIGINT, category_name TEXT)"
+        ))
+        conn.execute(text(
+            "INSERT INTO watchlist (type_id, type_name, group_id, group_name, "
+            "category_id, category_name) "
+            "VALUES (1, NULL, 10, NULL, 100, NULL)"
+        ))
+
+    ok = repair.migrate_target(fake_db, "watchlist", Watchlist, apply=True)
+
+    assert ok is True
+    with fake_db.engine.connect() as conn:
+        row = conn.execute(text(
+            "SELECT type_id, type_name, group_name, category_name FROM watchlist"
+        )).fetchone()
+    assert row.type_id == 1
+    assert row.type_name == ""
+    assert row.group_name == ""
+    assert row.category_name == ""
+
+
+def test_migrate_target_preserves_pk_for_marketstats(fake_db):
+    """Same regression coverage as watchlist, but for the marketstats
+    table — it has more columns and is also in the migration TARGETS list.
+    """
+    with fake_db.engine.begin() as conn:
+        conn.execute(text("DROP TABLE IF EXISTS marketstats"))
+        conn.execute(text(
+            "CREATE TABLE marketstats ("
+            "type_id BIGINT, total_volume_remain BIGINT, "
+            "min_price REAL, price REAL, avg_price REAL, avg_volume REAL, "
+            "group_id BIGINT, type_name TEXT, group_name TEXT, "
+            "category_id BIGINT, category_name TEXT, "
+            "days_remaining REAL, last_update TEXT)"
+        ))
+        conn.execute(text(
+            "INSERT INTO marketstats VALUES "
+            "(1, 100, 1.0, 2.0, 1.5, 50.0, 10, 'item', 'g', "
+            "100, 'c', 30.0, '2024-01-01 00:00:00')"
+        ))
+
+    ok = repair.migrate_target(fake_db, "marketstats", MarketStats, apply=True)
+
+    assert ok is True
+    pk_after = repair.get_pk_cols(fake_db, "marketstats")
+    assert pk_after == ["type_id"]
+    with fake_db.engine.connect() as conn:
+        count = conn.execute(text("SELECT COUNT(*) FROM marketstats")).scalar()
+    assert count == 1

--- a/tests/test_schema_integrity.py
+++ b/tests/test_schema_integrity.py
@@ -1,10 +1,9 @@
 """Schema integrity checks for tables defined in ``mkts_backend.db.models``.
 
-These tests guard against the regression that motivated PR-hotfix:
-production ``marketstats`` and ``watchlist`` tables had been recreated by
-``pandas.DataFrame.to_sql(if_exists="replace")`` and lost their primary
-keys, which silently disabled ``ON CONFLICT DO UPDATE`` and let duplicate
-rows accumulate.
+Guards Base-defined tables (watchlist, marketstats) against PRIMARY KEY
+loss caused by ``pandas.DataFrame.to_sql(if_exists='replace')``, which
+recreates the table from DataFrame dtype metadata only and silently drops
+ON CONFLICT semantics.
 """
 from __future__ import annotations
 
@@ -25,17 +24,23 @@ def get_pk_cols(engine, table_name: str) -> list[str]:
 
 
 def assert_table_matches_model(engine, model) -> None:
-    """Verify a live table's PK matches the SQLAlchemy model.
-
-    Raises AssertionError with a specific message if the DB is out of sync
-    with the Base definition — that is the failure mode we want surfaced.
-    """
+    """Verify a live table's PK matches the SQLAlchemy model."""
     expected = [c.name for c in model.__table__.primary_key.columns]
     actual = get_pk_cols(engine, model.__tablename__)
     assert actual == expected, (
         f"PK mismatch on {model.__tablename__}: "
         f"model defines {expected}, DB has {actual}"
     )
+
+
+class _FakeDB:
+    """Stand-in for DatabaseConfig exposing only ``.engine`` / ``.remote_engine``."""
+
+    def __init__(self, engine, alias: str = "fake"):
+        self.engine = engine
+        self.remote_engine = engine
+        self.alias = alias
+        self.path = ":memory:"
 
 
 # ---- fixtures ---------------------------------------------------------------
@@ -66,6 +71,17 @@ def watchlist_csv(tmp_path):
     return path
 
 
+@pytest.fixture
+def empty_watchlist_csv(tmp_path):
+    """A CSV with only headers — should be refused, not silently truncate."""
+    path = tmp_path / "empty.csv"
+    pd.DataFrame(
+        columns=["type_id", "type_name", "group_id", "group_name",
+                 "category_id", "category_name"]
+    ).to_csv(path, index=False)
+    return path
+
+
 # ---- 1) Base-built DB matches its models ------------------------------------
 
 
@@ -75,13 +91,12 @@ def test_base_create_all_yields_expected_pk(base_engine, model):
     assert_table_matches_model(base_engine, model)
 
 
-# ---- 2) Validator catches the historic pandas-replace bug -------------------
+# ---- 2) Validator catches the pandas-replace bug ----------------------------
 
 
 def test_pandas_replace_drops_pk_and_validator_catches_it(tmp_path):
-    """If anything calls ``to_sql(if_exists='replace')`` on a Base table,
-    the PK is lost and ``assert_table_matches_model`` must fail loudly.
-    Exists so the regression that took prod down has a named test.
+    """``to_sql(if_exists='replace')`` on a Base table loses its PK; the
+    validator must fail loudly so any future regression is caught.
     """
     engine = create_engine(f"sqlite:///{tmp_path}/regress.db")
     Base.metadata.create_all(engine)
@@ -99,18 +114,7 @@ def test_pandas_replace_drops_pk_and_validator_catches_it(tmp_path):
     engine.dispose()
 
 
-# ---- 3) Each fixed writer preserves the PK ---------------------------------
-# These are the tests that actually catch a code regression: if anyone
-# reverts the watchlist writers to ``to_sql(if_exists="replace")`` or
-# similar pandas-shaped recreates, these will fail.
-
-
-class _FakeDB:
-    """Minimal stand-in for DatabaseConfig that only exposes ``.engine``."""
-
-    def __init__(self, engine):
-        self.engine = engine
-        self.alias = "fake"
+# ---- 3) Watchlist writers preserve PK ---------------------------------------
 
 
 def test_update_watchlist_data_preserves_pk(base_engine, watchlist_csv, monkeypatch):
@@ -130,10 +134,7 @@ def test_update_watchlist_data_preserves_pk(base_engine, watchlist_csv, monkeypa
 def test_restore_watchlist_from_csv_preserves_pk(
     base_engine, watchlist_csv, monkeypatch
 ):
-    # restore_watchlist_from_csv builds a DatabaseConfig internally;
-    # patch the constructor so the writer uses our temp engine.
     fake = _FakeDB(base_engine)
-    fake.remote_engine = base_engine
     monkeypatch.setattr(
         "mkts_backend.utils.db_utils.DatabaseConfig",
         lambda *a, **kw: fake,
@@ -148,25 +149,66 @@ def test_restore_watchlist_from_csv_preserves_pk(
     assert [r.type_id for r in rows] == [1, 2]
 
 
-def test_add_missing_items_to_watchlist_uses_on_conflict(base_engine, monkeypatch):
-    """Pre-loading the table and re-inserting the same type_id must not
-    raise and must not produce a duplicate row — proving the writer uses
-    ``on_conflict_do_nothing`` rather than relying on the app-level filter
-    alone.
-    """
-    # Pre-seed one row, then attempt a second insert of the same type_id.
-    with base_engine.begin() as conn:
-        conn.execute(
-            text(
-                "INSERT INTO watchlist "
-                "(type_id, type_name, group_id, group_name, category_id, category_name) "
-                "VALUES (1, 'orig', 10, 'g', 100, 'c')"
-            )
-        )
+# ---- 4) Watchlist writers refuse empty input (no DELETE-then-nothing) -------
 
-    # add_missing_items_to_watchlist filters via pandas; bypass that path by
-    # exercising the underlying upsert directly.
+
+def test_update_watchlist_data_refuses_empty_csv(
+    base_engine, empty_watchlist_csv, monkeypatch
+):
+    """An empty CSV must NOT silently DELETE the watchlist."""
+    monkeypatch.setattr(
+        "mkts_backend.utils.utils.wcmkt_db", _FakeDB(base_engine)
+    )
+    with base_engine.begin() as conn:
+        conn.execute(text(
+            "INSERT INTO watchlist (type_id, type_name, group_id, group_name, category_id, category_name) VALUES (1, 'orig', 10, 'g', 100, 'c')"
+        ))
+    from mkts_backend.utils.utils import update_watchlist_data
+
+    with pytest.raises(ValueError, match="empty CSV"):
+        update_watchlist_data(esi=None, watchlist_csv=str(empty_watchlist_csv))
+
+    with base_engine.connect() as conn:
+        count = conn.execute(text("SELECT COUNT(*) FROM watchlist")).scalar()
+    assert count == 1, "watchlist must be untouched after refusal"
+
+
+def test_restore_watchlist_from_csv_refuses_empty_csv(
+    base_engine, empty_watchlist_csv, monkeypatch
+):
+    """An empty CSV must NOT silently DELETE the watchlist."""
+    fake = _FakeDB(base_engine)
+    monkeypatch.setattr(
+        "mkts_backend.utils.db_utils.DatabaseConfig",
+        lambda *a, **kw: fake,
+    )
+    with base_engine.begin() as conn:
+        conn.execute(text(
+            "INSERT INTO watchlist (type_id, type_name, group_id, group_name, category_id, category_name) VALUES (1, 'orig', 10, 'g', 100, 'c')"
+        ))
+    from mkts_backend.utils.db_utils import restore_watchlist_from_csv
+
+    with pytest.raises(ValueError, match="empty CSV"):
+        restore_watchlist_from_csv(csv_file=str(empty_watchlist_csv), remote=False)
+
+    with base_engine.connect() as conn:
+        count = conn.execute(text("SELECT COUNT(*) FROM watchlist")).scalar()
+    assert count == 1, "watchlist must be untouched after refusal"
+
+
+# ---- 5) ON CONFLICT DO NOTHING semantics ------------------------------------
+
+
+def test_sqlite_on_conflict_do_nothing_skips_duplicate(base_engine):
+    """Pins the SQLite/SQLAlchemy upsert behavior the writers depend on:
+    re-inserting an existing PK is a no-op (rowcount 0), not an error.
+    """
     from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+    with base_engine.begin() as conn:
+        conn.execute(text(
+            "INSERT INTO watchlist (type_id, type_name, group_id, group_name, category_id, category_name) VALUES (1, 'orig', 10, 'g', 100, 'c')"
+        ))
 
     stmt = sqlite_insert(Watchlist.__table__).values(
         type_id=1, type_name="dup", group_id=10,
@@ -175,9 +217,82 @@ def test_add_missing_items_to_watchlist_uses_on_conflict(base_engine, monkeypatc
 
     with base_engine.begin() as conn:
         result = conn.execute(stmt)
-    assert result.rowcount == 0  # conflict, no insert
+    assert result.rowcount == 0
 
     with base_engine.connect() as conn:
         rows = conn.execute(text("SELECT type_id, type_name FROM watchlist")).fetchall()
     assert len(rows) == 1
     assert rows[0].type_name == "orig"
+
+
+def test_add_missing_items_to_watchlist_skips_existing_type_id(
+    base_engine, monkeypatch
+):
+    """``add_missing_items_to_watchlist`` must not duplicate existing rows
+    when called with a type_id already in the watchlist.
+    """
+    fake = _FakeDB(base_engine)
+    monkeypatch.setattr(
+        "mkts_backend.utils.db_utils.DatabaseConfig",
+        lambda *a, **kw: fake,
+    )
+    monkeypatch.setattr(
+        "mkts_backend.utils.db_utils.get_type_info",
+        lambda type_ids, remote=False: pd.DataFrame([
+            {"type_id": 1, "type_name": "from_sde", "group_id": 10,
+             "group_name": "g", "category_id": 100, "category_name": "c"},
+            {"type_id": 2, "type_name": "new", "group_id": 20,
+             "group_name": "g", "category_id": 200, "category_name": "c"},
+        ]),
+    )
+    with base_engine.begin() as conn:
+        conn.execute(text(
+            "INSERT INTO watchlist (type_id, type_name, group_id, group_name, category_id, category_name) VALUES (1, 'orig', 10, 'g', 100, 'c')"
+        ))
+
+    from mkts_backend.utils.db_utils import add_missing_items_to_watchlist
+
+    add_missing_items_to_watchlist([1, 2], remote=False, db_alias="wcmkt")
+
+    with base_engine.connect() as conn:
+        rows = conn.execute(text(
+            "SELECT type_id, type_name FROM watchlist ORDER BY type_id"
+        )).fetchall()
+    assert [(r.type_id, r.type_name) for r in rows] == [(1, "orig"), (2, "new")], (
+        "row 1 must keep its original name; row 2 must be inserted"
+    )
+
+
+# ---- 6) marketstats writer preserves PK -------------------------------------
+
+
+def test_upsert_marketstats_preserves_pk(base_engine, monkeypatch):
+    """``upsert_database(MarketStats, df)`` must not lose the type_id PK.
+    Uses the wipe_replace branch (the bug-prone one) since marketstats is
+    listed in [wipe_replace] tables in settings.toml.
+    """
+    fake = _FakeDB(base_engine, alias="wcmkt")
+    monkeypatch.setattr(
+        "mkts_backend.db.db_handlers._get_db",
+        lambda market_ctx=None: fake,
+    )
+
+    df = pd.DataFrame([
+        {
+            "type_id": 12345, "type_name": "Item",
+            "total_volume_remain": 100, "min_price": 1.0,
+            "price": 2.0, "avg_price": 1.5, "avg_volume": 50.0,
+            "group_id": 1, "group_name": "G",
+            "category_id": 2, "category_name": "C",
+            "days_remaining": 30.0,
+            "last_update": pd.Timestamp.now(tz="UTC").tz_localize(None),
+        }
+    ])
+
+    from mkts_backend.db.db_handlers import upsert_database
+
+    assert upsert_database(MarketStats, df) is True
+    assert_table_matches_model(base_engine, MarketStats)
+    with base_engine.connect() as conn:
+        ids = conn.execute(text("SELECT type_id FROM marketstats")).fetchall()
+    assert [r.type_id for r in ids] == [12345]

--- a/tests/test_schema_integrity.py
+++ b/tests/test_schema_integrity.py
@@ -1,0 +1,183 @@
+"""Schema integrity checks for tables defined in ``mkts_backend.db.models``.
+
+These tests guard against the regression that motivated PR-hotfix:
+production ``marketstats`` and ``watchlist`` tables had been recreated by
+``pandas.DataFrame.to_sql(if_exists="replace")`` and lost their primary
+keys, which silently disabled ``ON CONFLICT DO UPDATE`` and let duplicate
+rows accumulate.
+"""
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+from sqlalchemy import create_engine, text
+
+from mkts_backend.db.models import Base, MarketStats, Watchlist
+
+
+# ---- helpers ----------------------------------------------------------------
+
+
+def get_pk_cols(engine, table_name: str) -> list[str]:
+    with engine.connect() as conn:
+        rows = conn.execute(text(f"PRAGMA table_info({table_name})")).fetchall()
+    return [r.name for r in rows if r.pk]
+
+
+def assert_table_matches_model(engine, model) -> None:
+    """Verify a live table's PK matches the SQLAlchemy model.
+
+    Raises AssertionError with a specific message if the DB is out of sync
+    with the Base definition — that is the failure mode we want surfaced.
+    """
+    expected = [c.name for c in model.__table__.primary_key.columns]
+    actual = get_pk_cols(engine, model.__tablename__)
+    assert actual == expected, (
+        f"PK mismatch on {model.__tablename__}: "
+        f"model defines {expected}, DB has {actual}"
+    )
+
+
+# ---- fixtures ---------------------------------------------------------------
+
+
+@pytest.fixture
+def base_engine(tmp_path):
+    """A fresh SQLite engine with all Base tables created."""
+    engine = create_engine(f"sqlite:///{tmp_path}/integrity.db")
+    Base.metadata.create_all(engine)
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture
+def watchlist_csv(tmp_path):
+    """A CSV in the format expected by the watchlist writers."""
+    df = pd.DataFrame(
+        [
+            {"type_id": 1, "type_name": "a", "group_id": 10,
+             "group_name": "g", "category_id": 100, "category_name": "c"},
+            {"type_id": 2, "type_name": "b", "group_id": 20,
+             "group_name": "g", "category_id": 200, "category_name": "c"},
+        ]
+    )
+    path = tmp_path / "watchlist.csv"
+    df.to_csv(path, index=False)
+    return path
+
+
+# ---- 1) Base-built DB matches its models ------------------------------------
+
+
+@pytest.mark.parametrize("model", [MarketStats, Watchlist])
+def test_base_create_all_yields_expected_pk(base_engine, model):
+    """create_all(Base) must produce tables whose PKs match the models."""
+    assert_table_matches_model(base_engine, model)
+
+
+# ---- 2) Validator catches the historic pandas-replace bug -------------------
+
+
+def test_pandas_replace_drops_pk_and_validator_catches_it(tmp_path):
+    """If anything calls ``to_sql(if_exists='replace')`` on a Base table,
+    the PK is lost and ``assert_table_matches_model`` must fail loudly.
+    Exists so the regression that took prod down has a named test.
+    """
+    engine = create_engine(f"sqlite:///{tmp_path}/regress.db")
+    Base.metadata.create_all(engine)
+    assert_table_matches_model(engine, Watchlist)  # sanity
+
+    pd.DataFrame(
+        [
+            {"type_id": 1, "type_name": "a", "group_id": 10,
+             "group_name": "g", "category_id": 100, "category_name": "c"},
+        ]
+    ).to_sql("watchlist", engine, if_exists="replace", index=False)
+
+    with pytest.raises(AssertionError, match="PK mismatch on watchlist"):
+        assert_table_matches_model(engine, Watchlist)
+    engine.dispose()
+
+
+# ---- 3) Each fixed writer preserves the PK ---------------------------------
+# These are the tests that actually catch a code regression: if anyone
+# reverts the watchlist writers to ``to_sql(if_exists="replace")`` or
+# similar pandas-shaped recreates, these will fail.
+
+
+class _FakeDB:
+    """Minimal stand-in for DatabaseConfig that only exposes ``.engine``."""
+
+    def __init__(self, engine):
+        self.engine = engine
+        self.alias = "fake"
+
+
+def test_update_watchlist_data_preserves_pk(base_engine, watchlist_csv, monkeypatch):
+    monkeypatch.setattr(
+        "mkts_backend.utils.utils.wcmkt_db", _FakeDB(base_engine)
+    )
+    from mkts_backend.utils.utils import update_watchlist_data
+
+    update_watchlist_data(esi=None, watchlist_csv=str(watchlist_csv))
+
+    assert_table_matches_model(base_engine, Watchlist)
+    with base_engine.connect() as conn:
+        rows = conn.execute(text("SELECT type_id FROM watchlist ORDER BY type_id")).fetchall()
+    assert [r.type_id for r in rows] == [1, 2]
+
+
+def test_restore_watchlist_from_csv_preserves_pk(
+    base_engine, watchlist_csv, monkeypatch
+):
+    # restore_watchlist_from_csv builds a DatabaseConfig internally;
+    # patch the constructor so the writer uses our temp engine.
+    fake = _FakeDB(base_engine)
+    fake.remote_engine = base_engine
+    monkeypatch.setattr(
+        "mkts_backend.utils.db_utils.DatabaseConfig",
+        lambda *a, **kw: fake,
+    )
+    from mkts_backend.utils.db_utils import restore_watchlist_from_csv
+
+    restore_watchlist_from_csv(csv_file=str(watchlist_csv), remote=False)
+
+    assert_table_matches_model(base_engine, Watchlist)
+    with base_engine.connect() as conn:
+        rows = conn.execute(text("SELECT type_id FROM watchlist ORDER BY type_id")).fetchall()
+    assert [r.type_id for r in rows] == [1, 2]
+
+
+def test_add_missing_items_to_watchlist_uses_on_conflict(base_engine, monkeypatch):
+    """Pre-loading the table and re-inserting the same type_id must not
+    raise and must not produce a duplicate row — proving the writer uses
+    ``on_conflict_do_nothing`` rather than relying on the app-level filter
+    alone.
+    """
+    # Pre-seed one row, then attempt a second insert of the same type_id.
+    with base_engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO watchlist "
+                "(type_id, type_name, group_id, group_name, category_id, category_name) "
+                "VALUES (1, 'orig', 10, 'g', 100, 'c')"
+            )
+        )
+
+    # add_missing_items_to_watchlist filters via pandas; bypass that path by
+    # exercising the underlying upsert directly.
+    from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+    stmt = sqlite_insert(Watchlist.__table__).values(
+        type_id=1, type_name="dup", group_id=10,
+        group_name="g", category_id=100, category_name="c",
+    ).on_conflict_do_nothing(index_elements=["type_id"])
+
+    with base_engine.begin() as conn:
+        result = conn.execute(stmt)
+    assert result.rowcount == 0  # conflict, no insert
+
+    with base_engine.connect() as conn:
+        rows = conn.execute(text("SELECT type_id, type_name FROM watchlist")).fetchall()
+    assert len(rows) == 1
+    assert rows[0].type_name == "orig"


### PR DESCRIPTION
Introduces guards for duplicate watchlist entries and ensures compliance with db models. Adds script for migration to fix broken schemas.